### PR TITLE
mods/desktop: Re-enable ozone wayland

### DIFF
--- a/mods/desktop/environment/sessionVariables.nix
+++ b/mods/desktop/environment/sessionVariables.nix
@@ -1,6 +1,3 @@
 {
-  NIXOS_OZONE_WL =
-    if environments.${cfg.environment}.wayland
-    then "1"
-    else "";
+  NIXOS_OZONE_WL = "1";
 }

--- a/mods/desktop/environment/sessionVariables.nix
+++ b/mods/desktop/environment/sessionVariables.nix
@@ -1,6 +1,6 @@
 {
-  #NIXOS_OZONE_WL =
-  #  if environments.${cfg.environment}.wayland
-  #  then "1"
-  #  else "";
+  NIXOS_OZONE_WL =
+    if environments.${cfg.environment}.wayland
+    then "1"
+    else "";
 }


### PR DESCRIPTION
1password now has wayland disabled in NixOS/nixpkgs@a5a73963dd913a55dfee7175d12554ccb54eeffb