### PR TITLE
fix: Correct starship cmake format string

### DIFF
--- a/modules/home/shell/default.nix
+++ b/modules/home/shell/default.nix
@@ -111,7 +111,7 @@
         };
 
         cmake = {
-          format = "[$symbol]($version)]($style) ";
+          format = "[$symbol$version]($style) ";
           style = "bold cyan";
         };
 


### PR DESCRIPTION
## Summary
- The cmake module's `format` had an unmatched bracket (`[$symbol]($version)]($style)`), breaking how it renders in the prompt.
- Replaced with `[$symbol$version]($style)` to match the surrounding format conventions.

## Test plan
- [ ] Confirm cmake prompt segment renders correctly in a directory containing a `CMakeLists.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)