### PR TITLE
docs: Warn against bumping system.stateVersion

### DIFF
--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -119,5 +119,6 @@
 
   systemd.network.networks."10-ethernet".matchConfig.Name = "enp7s0";
 
+  # Do not change. See `man configuration.nix` — pins stateful defaults to NixOS version at install time.
   system.stateVersion = "23.05";
 }

--- a/hosts/neo/configuration.nix
+++ b/hosts/neo/configuration.nix
@@ -19,6 +19,7 @@
     ./disko.nix
   ];
 
+  # Do not change. See `man configuration.nix` — pins stateful defaults to NixOS version at install time.
   system.stateVersion = "21.11";
 
   nixpkgs.hostPlatform = "x86_64-linux";

--- a/hosts/oracle/configuration.nix
+++ b/hosts/oracle/configuration.nix
@@ -106,6 +106,7 @@
       allowReboot = true;
       dates = "03:00";
     };
+    # Do not change. See `man configuration.nix` — pins stateful defaults to NixOS version at install time.
     stateVersion = "21.11";
   };
   systemd = {

--- a/hosts/trinity/configuration.nix
+++ b/hosts/trinity/configuration.nix
@@ -190,6 +190,7 @@ in {
   networking.wireless.iwd.enable = true;
   networking.hostName = "trinity";
   stylix.autoEnable = false;
+  # Do not change. See `man configuration.nix` — pins stateful defaults to NixOS version at install time.
   system.stateVersion = "25.11";
 
   services = {


### PR DESCRIPTION
## Summary
- Added a one-line comment above each host's `system.stateVersion` to deter accidental bumps.

## Test plan
- [ ] No build/eval impact — comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)