### PR TITLE
docs: Explain checks/packages drift-detection pairs

### DIFF
--- a/checks/hydra-spec.nix
+++ b/checks/hydra-spec.nix
@@ -1,3 +1,5 @@
+# Verifies the committed .hydra/spec.json matches the output of packages/hydra-spec.nix.
+# If this check fails, regenerate the spec from the package and commit it.
 {
   pkgs,
   perSystem,

--- a/checks/mergify.nix
+++ b/checks/mergify.nix
@@ -1,3 +1,5 @@
+# Verifies the committed .mergify.yml matches the output of packages/mergify.nix.
+# If this check fails, regenerate the config from the package and commit it.
 {
   pkgs,
   perSystem,

--- a/packages/hydra-spec.nix
+++ b/packages/hydra-spec.nix
@@ -1,3 +1,5 @@
+# Builds the Hydra jobset spec JSON. The committed copy lives at .hydra/spec.json
+# and is validated against this output by checks/hydra-spec.nix (drift detection).
 {
   pkgs,
   pname,

--- a/packages/mergify.nix
+++ b/packages/mergify.nix
@@ -1,3 +1,5 @@
+# Generates the Mergify config from the flake's checks. The committed copy lives at
+# .mergify.yml and is validated against this output by checks/mergify.nix.
 {
   pkgs,
   pname,


### PR DESCRIPTION
## Summary
- Added header comments on \`packages/hydra-spec.nix\`, \`checks/hydra-spec.nix\`, \`packages/mergify.nix\`, and \`checks/mergify.nix\` explaining the drift-detection relationship (the \`checks/\` file validates the committed file in the repo against the output of its \`packages/\` sibling).

## Test plan
- [ ] No functional change — header comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)