### PR TITLE
refactor: Consolidate agenix into common, normalize disko alias

### DIFF
--- a/hosts/neo/configuration.nix
+++ b/hosts/neo/configuration.nix
@@ -5,8 +5,7 @@
   ...
 }: {
   imports = with flake.nixosModules; [
-    inputs.agenix.nixosModules.default
-    inputs.disko.nixosModules.disko
+    inputs.disko.nixosModules.default
     xps-9560
     common
     virtualisation

--- a/modules/nixos/attic-watch/default.nix
+++ b/modules/nixos/attic-watch/default.nix
@@ -1,12 +1,8 @@
 {
   config,
   pkgs,
-  inputs,
   ...
 }: {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
   age.secrets.attic-auth.file = ../../../secrets/attic_auth.age;
   systemd.services.attic-watch-store = {
     wantedBy = ["multi-user.target"];

--- a/modules/nixos/atticd/default.nix
+++ b/modules/nixos/atticd/default.nix
@@ -1,12 +1,4 @@
-{
-  config,
-  inputs,
-  ...
-}: {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
-
+{config, ...}: {
   age.secrets.attic-token.file = ../../../secrets/${config.networking.hostName}/attic_token.age;
 
   services = {

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -6,6 +6,7 @@
 }: {
   imports = [
     inputs.stylix.nixosModules.stylix
+    inputs.agenix.nixosModules.default
   ];
   i18n.defaultLocale = "en_CA.UTF-8";
   boot = {

--- a/modules/nixos/firefly/default.nix
+++ b/modules/nixos/firefly/default.nix
@@ -1,12 +1,4 @@
-{
-  config,
-  inputs,
-  ...
-}: {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
-
+{config, ...}: {
   age.secrets.firefly-id = {
     file = ../../../secrets/${config.networking.hostName}/firefly_id.age;
     owner = config.services.firefly-iii.user;

--- a/modules/nixos/hydra/default.nix
+++ b/modules/nixos/hydra/default.nix
@@ -1,14 +1,6 @@
-{
-  config,
-  inputs,
-  ...
-}: let
+{config, ...}: let
   narCache = "/var/cache/hydra/nar-cache";
 in {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
-
   age.secrets = {
     hydra = {
       file = ../../../secrets/${config.networking.hostName}/hydra.age;

--- a/modules/nixos/immich/default.nix
+++ b/modules/nixos/immich/default.nix
@@ -2,13 +2,8 @@
   config,
   pkgs,
   lib,
-  inputs,
   ...
 }: {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
-
   age.secrets.immich.file = ../../../secrets/${config.networking.hostName}/immich.age;
 
   services = {

--- a/modules/nixos/msmtp/default.nix
+++ b/modules/nixos/msmtp/default.nix
@@ -1,13 +1,9 @@
 {
   pkgs,
   config,
-  inputs,
   lib,
   ...
 }: {
-  imports = [
-    inputs.agenix.nixosModules.default
-  ];
   age.secrets.fastmail_pass.file = ../../../secrets/fastmail.age;
   programs.msmtp = {
     enable = true;

--- a/modules/nixos/nixarr/default.nix
+++ b/modules/nixos/nixarr/default.nix
@@ -5,7 +5,6 @@
 }: {
   imports = [
     inputs.nixarr.nixosModules.default
-    inputs.agenix.nixosModules.default
   ];
 
   age.secrets.vpn.file = ../../../secrets/vpn.age;

--- a/modules/nixos/zed/default.nix
+++ b/modules/nixos/zed/default.nix
@@ -6,7 +6,6 @@
   ...
 }: {
   imports = [
-    inputs.agenix.nixosModules.default
     inputs.self.nixosModules.msmtp
   ];
   age.secrets = {


### PR DESCRIPTION
## Summary
- agenix is enabled system-wide, so import \`inputs.agenix.nixosModules.default\` once in \`modules/nixos/common\` instead of in each module that defines secrets (8 modules + 1 host).
- Align neo's disko import alias with morpheus (\`.default\` instead of \`.disko\`).

## Test plan
- [ ] \`nixos-rebuild build --flake .#morpheus\` succeeds.
- [ ] \`nixos-rebuild build --flake .#neo\` succeeds.
- [ ] Secrets continue to decrypt on each host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)