### PR TITLE
refactor(localProxy): Guard port magic default

### DIFF
--- a/modules/nixos/localProxy/default.nix
+++ b/modules/nixos/localProxy/default.nix
@@ -42,9 +42,15 @@ in {
                   };
 
                   port = lib.mkOption {
-                    description = "Local port to proxy to";
+                    description = ''
+                      Local port to proxy to. Defaults to `services.<name>.port`
+                      when that option exists; otherwise null (no proxyPass).
+                    '';
                     type = lib.types.nullOr lib.types.port;
-                    default = globalConfig.services.${name}.port;
+                    default =
+                      if (globalConfig.services ? ${name} && globalConfig.services.${name} ? port)
+                      then globalConfig.services.${name}.port
+                      else null;
                   };
 
                   extraConfig = lib.mkOption {


### PR DESCRIPTION
## Summary
- \`services.localProxy.subDomains.<name>.port\` defaulted to \`config.services.\${name}.port\`, which evaluates lazily but would throw on attribute access if the upstream module didn't expose a \`port\` option.
- Now falls back to \`null\` (no \`proxyPass\`) when the service or its \`port\` option doesn't exist, and documents the convention in the option description.

## Test plan
- [ ] \`nixos-rebuild build --flake .#morpheus\` succeeds.
- [ ] All existing localProxy registrations continue to bind their expected ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)