### PR TITLE
refactor: Dedup SSH matchBlocks with helper functions

### DIFF
--- a/modules/home/lsanche/default.nix
+++ b/modules/home/lsanche/default.nix
@@ -24,45 +24,41 @@
     matchBlocks = let
       keys = (import ../../../pubKeys.nix).lsanche;
       gitKeys = import ./gitKeys.nix;
+      mkPubkeyFile = name: key: pkgs.writeText "${name}.pub" "${key}\n";
+      mkGitForge = {
+        hostname,
+        keyName,
+        key,
+      }: {
+        inherit hostname;
+        port = 443;
+        user = "git";
+        identitiesOnly = true;
+        identityFile = "${mkPubkeyFile keyName key}";
+      };
     in
       (builtins.mapAttrs (name: value: {
           hostname = name;
-          identityFile = "${(pkgs.writeText "lsanche-${name}.pub" ''
-            ${value}
-          '')}";
+          identityFile = "${mkPubkeyFile "lsanche-${name}" value}";
           identitiesOnly = true;
           forwardAgent = true;
         })
         keys)
       // {
-        "github.com" = {
+        "github.com" = mkGitForge {
           hostname = "ssh.github.com";
-          port = 443;
-          user = "git";
-          identitiesOnly = true;
-          identityFile = "${(pkgs.writeText "github.pub" ''
-            ${gitKeys.github}
-          '')}";
+          keyName = "github";
+          key = gitKeys.github;
         };
-
-        "gitlab.com" = {
+        "gitlab.com" = mkGitForge {
           hostname = "altssh.gitlab.com";
-          port = 443;
-          user = "git";
-          identitiesOnly = true;
-          identityFile = "${(pkgs.writeText "gitlab.pub" ''
-            ${gitKeys.gitlab}
-          '')}";
+          keyName = "gitlab";
+          key = gitKeys.gitlab;
         };
-
-        "gitlabalt" = {
+        "gitlabalt" = mkGitForge {
           hostname = "altssh.gitlab.com";
-          port = 443;
-          user = "git";
-          identitiesOnly = true;
-          identityFile = "${(pkgs.writeText "gitlab.pub" ''
-            ${gitKeys.gitlabalt}
-          '')}";
+          keyName = "gitlabalt";
+          key = gitKeys.gitlabalt;
         };
       };
   };


### PR DESCRIPTION
## Summary
- Extracted \`mkPubkeyFile\` and \`mkGitForge\` helpers in \`modules/home/lsanche/default.nix\`.
- Collapses 3 nearly-identical GitHub/GitLab match blocks and removes the heredoc-induced leading newline in each generated \`*.pub\` file.

## Test plan
- [ ] \`home-manager switch\` succeeds.
- [ ] \`ssh -T git@github.com\` works.
- [ ] \`ssh -T git@gitlab.com\` works.
- [ ] Generated \`~/.ssh/config\` is structurally equivalent to before (only whitespace inside the pubkey files should differ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)