### PR TITLE
refactor: Move builder + morpheus host key into pubKeys.nix

### DIFF
--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -69,7 +69,7 @@
     group = "builder";
     shell = pkgs.bashInteractive;
     openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL+/C/kSJUTqvnRXdq86551K1k1x1YG57Oc68b9nDsED"
+      (import ../../pubKeys.nix).builders.morpheus
     ];
   };
 

--- a/hosts/neo/configuration.nix
+++ b/hosts/neo/configuration.nix
@@ -2,6 +2,7 @@
   inputs,
   flake,
   config,
+  pkgs,
   ...
 }: {
   imports = with flake.nixosModules; [
@@ -44,7 +45,9 @@
         supportedFeatures = ["kvm" "nixos-test" "big-parallel" "benchmark" "gccarch-znver3" "gccarch-skylake"];
         maxJobs = 32;
         speedFactor = 4;
-        publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUtKd29tOXdrY2N0MUVjQmlMZ2EyMmU0bEplUTJBaHpOeUNDR2dqcmVVZC8gcm9vdEBtb3JwaGV1cwo=";
+        publicHostKey = builtins.readFile (pkgs.runCommand "morpheus-host-key-b64" {} ''
+          printf '%s\n' "${(import ../../pubKeys.nix).hostKeys.morpheus}" | base64 -w0 > $out
+        '');
         sshUser = "builder";
         sshKey = config.age.secrets.builder.path;
       }

--- a/pubKeys.nix
+++ b/pubKeys.nix
@@ -5,4 +5,15 @@
     oracle = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG8hU9yYrAg76q1zp6rfhOBxSjwSwzQFpJTdBynWSCKA";
     trinity = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIGB5Ui/De31w1o/Z6ce0gNt6LDC+1W1skbNtQrw4DE6";
   };
+
+  # Authorized keys for remote builders connecting INTO a host (sshUser = builder).
+  builders = {
+    morpheus = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL+/C/kSJUTqvnRXdq86551K1k1x1YG57Oc68b9nDsED";
+  };
+
+  # SSH host public keys (the `/etc/ssh/ssh_host_*_key.pub` of each host).
+  # Used by remote build clients to verify they're talking to the right server.
+  hostKeys = {
+    morpheus = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKJwom9wkcct1EcBiLga22e4lJeQ2AhzNyCCGgjreUd/ root@morpheus";
+  };
 }


### PR DESCRIPTION
## Summary
- The morpheus builder authorized key and morpheus's host pubkey (used by neo for remote builds) now live in \`pubKeys.nix\` instead of inlined in each host config.
- neo derives the base64-encoded \`publicHostKey\` via IFD on a tiny \`runCommand\` so the human-readable form stays the source of truth.
- Round-trip verified: re-encoded value is byte-identical to the previous inline blob.

## Test plan
- [ ] \`nixos-rebuild build --flake .#morpheus\` succeeds.
- [ ] \`nixos-rebuild build --flake .#neo\` succeeds; neo can still remote-build on morpheus (\`nix build --builders 'ssh://builder@morpheus ...'\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)