### PR TITLE
refactor: Move syncthing out of common into its own module

### DIFF
--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -12,6 +12,7 @@
     ]
     ++ (with flake.nixosModules; [
       common
+      syncthing
       virtualisation
       zed
       desktop

--- a/hosts/neo/configuration.nix
+++ b/hosts/neo/configuration.nix
@@ -9,6 +9,7 @@
     inputs.disko.nixosModules.disko
     xps-9560
     common
+    syncthing
     virtualisation
     desktop
     niri

--- a/hosts/oracle/configuration.nix
+++ b/hosts/oracle/configuration.nix
@@ -85,7 +85,6 @@
       };
     };
     resolved.settings.Resolve.DNSStubListener = false;
-    syncthing.enable = lib.mkForce false;
     tailscale = {
       useRoutingFeatures = "server";
     };

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -99,13 +99,6 @@
       };
       openFirewall = false;
     };
-    syncthing = {
-      enable = true;
-      user = "lsanche";
-      dataDir = "/home/lsanche";
-      configDir = "/home/lsanche/.config/syncthing";
-      openDefaultPorts = true;
-    };
   };
 
   users = let

--- a/modules/nixos/syncthing/default.nix
+++ b/modules/nixos/syncthing/default.nix
@@ -1,0 +1,9 @@
+{
+  services.syncthing = {
+    enable = true;
+    user = "lsanche";
+    dataDir = "/home/lsanche";
+    configDir = "/home/lsanche/.config/syncthing";
+    openDefaultPorts = true;
+  };
+}


### PR DESCRIPTION
## Summary
- New \`modules/nixos/syncthing\` module encapsulates the syncthing config previously in \`common\`.
- morpheus and neo import it explicitly; trinity (size-constrained appliance image, 2G squashfs nix-store) no longer pulls syncthing + go.
- Removed the now-redundant \`syncthing.enable = lib.mkForce false\` override on oracle.

## Test plan
- [ ] \`nix eval .#nixosConfigurations.trinity.config.services.syncthing.enable\` returns \`false\`.
- [ ] \`nix eval .#nixosConfigurations.morpheus.config.services.syncthing.enable\` returns \`true\`.
- [ ] \`nix eval .#nixosConfigurations.neo.config.services.syncthing.enable\` returns \`true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)