### PR TITLE
refactor: Split ACME defaults out of localProxy into own module

### DIFF
--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -19,6 +19,7 @@
       secureboot
       hydraCache
       attic-watch
+      acme
       localProxy
       server
       postgresql
@@ -36,6 +37,8 @@
       asus-desktop
       zfs
     ]);
+
+  services.lyndenoAcme.enable = true;
 
   age = {
     secrets = {

--- a/modules/nixos/acme/default.nix
+++ b/modules/nixos/acme/default.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.lyndenoAcme;
+in {
+  options.services.lyndenoAcme = {
+    enable = lib.mkEnableOption "ACME wildcard cert for this host's domain via acme-dns";
+
+    email = lib.mkOption {
+      type = lib.types.str;
+      default = "lsanche@lyndeno.ca";
+      description = "Contact email registered with Let's Encrypt.";
+    };
+
+    acmeDnsEndpoint = lib.mkOption {
+      type = lib.types.str;
+      default = "http://oracle:8080";
+      description = "Base URL of the acme-dns server used for DNS-01 challenges.";
+    };
+
+    certGroup = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default =
+        if config.services.nginx.enable
+        then config.services.nginx.group
+        else null;
+      description = "Group to grant read access to the cert files (typically the reverse proxy's group).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.acme = {
+      acceptTerms = true;
+      defaults = {
+        inherit (cfg) email;
+        dnsProvider = "acme-dns";
+        environmentFile = pkgs.writeText "acme-env" ''
+          ACME_DNS_API_BASE=${cfg.acmeDnsEndpoint}
+          ACME_DNS_STORAGE_PATH=/var/lib/acme/.lego-acme-dns-accounts.json
+        '';
+      };
+      certs."${config.networking.domain}" =
+        {
+          domain = "*.${config.networking.domain}";
+        }
+        // lib.optionalAttrs (cfg.certGroup != null) {
+          group = cfg.certGroup;
+        };
+    };
+  };
+}

--- a/modules/nixos/localProxy/default.nix
+++ b/modules/nixos/localProxy/default.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
   mkVirtualHost = _: cfg: let
@@ -61,22 +60,6 @@ in {
   };
 
   config = {
-    security.acme = {
-      acceptTerms = true;
-      defaults = {
-        email = "lsanche@lyndeno.ca";
-        dnsProvider = "acme-dns";
-        environmentFile = pkgs.writeText "acme-env" ''
-          ACME_DNS_API_BASE=http://oracle:8080
-          ACME_DNS_STORAGE_PATH=/var/lib/acme/.lego-acme-dns-accounts.json
-        '';
-      };
-      certs."${config.networking.domain}" = {
-        inherit (config.services.nginx) group;
-        domain = "*.${config.networking.domain}";
-      };
-    };
-
     services.nginx = {
       enable = true;
       clientMaxBodySize = "50000M";


### PR DESCRIPTION
## Summary
- \`localProxy\` no longer owns ACME — it just defines nginx virtual hosts.
- New \`modules/nixos/acme\` module owns the wildcard cert, DNS-01 acme-dns endpoint, and contact email, gated on \`services.lyndenoAcme.enable\`.
- morpheus opts in via \`services.lyndenoAcme.enable = true\` and now imports both modules.
- The cert's \`group\` defaults to nginx's group when nginx is enabled, else omitted — so the module no longer assumes nginx is present.

## Test plan
- [ ] \`nixos-rebuild build --flake .#morpheus\` succeeds.
- [ ] Existing TLS certs continue to renew on morpheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)