### PR TITLE
Split out wob command chains into packages

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,6 +30,8 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-webcam-picker
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-brightness
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.devshell-default
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.git-hooks
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.hydra-spec
@@ -61,4 +63,6 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-webcam-picker
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-brightness
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-volume
   name: Automatically merge dependabot updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,24 @@ Stylix is used globally for theming. Base color scheme is Gruvbox Dark Hard with
 2. Add host SSH key to `pubKeys.nix`
 3. Add the key to relevant secrets in `secrets/secrets.nix`
 4. Re-key secrets: `agenix -r`
+
+### Adding or Removing a Package (regenerate `.mergify.yml`)
+
+Packages live in `packages/<name>.nix` and checks in `checks/<name>.nix`; Blueprint exposes
+them as `pkgs.<name>` and flake checks. The CI merge-queue config `.mergify.yml` is **generated**
+from `packages/mergify.nix` (off `flake.checks`) and validated by `checks/mergify.nix`.
+
+**IMPORTANT:** Whenever you add or remove a file in `packages/` or `checks/`, or change the
+`passthru.tests` of any of them (each test becomes its own check), you MUST regenerate
+`.mergify.yml` in the same commit — otherwise the `mergify` CI check fails and the merge queue
+blocks. Regenerate and verify with:
+
+```bash
+# Regenerate the committed config from the generator package
+install -m 644 "$(nix build --no-link --print-out-paths .#mergify)" .mergify.yml
+
+# Verify it matches (this is exactly what CI runs; adjust arch if needed)
+nix build .#checks.x86_64-linux.mergify
+```
+
+Commit the updated `.mergify.yml` alongside the package/check change.

--- a/modules/home/niri/includes/keybinds.nix
+++ b/modules/home/niri/includes/keybinds.nix
@@ -33,14 +33,14 @@
 
       // Example volume keys mappings for PipeWire & WirePlumber.
       // The allow-when-locked=true property makes them work even when the session is locked.
-      XF86AudioRaiseVolume allow-when-locked=true { spawn "bash" "-c" "(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -q MUTED && echo 0 > $XDG_RUNTIME_DIR/wob.sock) || (wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%+ && wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $XDG_RUNTIME_DIR/wob.sock)"; }
-      XF86AudioLowerVolume allow-when-locked=true { spawn "bash" "-c" "(wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -q MUTED && echo 0 > $XDG_RUNTIME_DIR/wob.sock) || (wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%- && wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $XDG_RUNTIME_DIR/wob.sock)"; }
-      XF86AudioMute        allow-when-locked=true { spawn "bash" "-c" "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle && (wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -q MUTED && echo 0 > $XDG_RUNTIME_DIR/wob.sock) || wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $XDG_RUNTIME_DIR/wob.sock"; }
-      XF86AudioMicMute     allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
+      XF86AudioRaiseVolume allow-when-locked=true { spawn "${lib.getExe pkgs.wob-volume}" "up"; }
+      XF86AudioLowerVolume allow-when-locked=true { spawn "${lib.getExe pkgs.wob-volume}" "down"; }
+      XF86AudioMute        allow-when-locked=true { spawn "${lib.getExe pkgs.wob-volume}" "mute"; }
+      XF86AudioMicMute     allow-when-locked=true { spawn "${lib.getExe pkgs.wob-volume}" "mic-mute"; }
 
   		// Brightness
-  		XF86MonBrightnessUp allow-when-locked=true { spawn "bash" "-c" "brightnessctl set +5% | sed -En 's/.*\\(([0-9]+)%\\).*/\\1/p' > $XDG_RUNTIME_DIR/wob.sock"; }
-  		XF86MonBrightnessDown allow-when-locked=true { spawn "bash" "-c" "brightnessctl -n set 5%- | sed -En 's/.*\\(([0-9]+)%\\).*/\\1/p' > $XDG_RUNTIME_DIR/wob.sock"; }
+  		XF86MonBrightnessUp allow-when-locked=true { spawn "${lib.getExe pkgs.wob-brightness}" "up"; }
+  		XF86MonBrightnessDown allow-when-locked=true { spawn "${lib.getExe pkgs.wob-brightness}" "down"; }
 
       // Gamma
   		Mod+S hotkey-overlay-title="Cycle Night Shift Modes" allow-when-locked=true { spawn "bash" "-c" "systemctl --user kill --signal SIGUSR1 wlsunset.service"; }
@@ -52,9 +52,9 @@
       Mod+Y hotkey-overlay-title="Clipboard History" { spawn "${lib.getExe' pkgs.cliphist "cliphist-fuzzel-img"}"; }
 
       // Media
-      XF86AudioPrev allow-when-locked=true { spawn "bash" "-c" "playerctl previous"; }
-      XF86AudioNext allow-when-locked=true { spawn "bash" "-c" "playerctl next"; }
-      XF86AudioPlay allow-when-locked=true { spawn "bash" "-c" "playerctl play-pause"; }
+      XF86AudioPrev allow-when-locked=true { spawn "${lib.getExe pkgs.playerctl}" "previous"; }
+      XF86AudioNext allow-when-locked=true { spawn "${lib.getExe pkgs.playerctl}" "next"; }
+      XF86AudioPlay allow-when-locked=true { spawn "${lib.getExe pkgs.playerctl}" "play-pause"; }
 
       // Dynamic Casting
       Mod+M hotkey-overlay-title="Cast Focused Window" { set-dynamic-cast-window; }

--- a/packages/wob-brightness.nix
+++ b/packages/wob-brightness.nix
@@ -1,0 +1,42 @@
+{
+  pkgs,
+  pname,
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.writeShellApplication {
+    name = pname;
+
+    runtimeInputs = with pkgs; [
+      brightnessctl
+      gnused
+    ];
+
+    text = ''
+      # Pull the "(NN%)" percentage out of brightnessctl's output.
+      percent() {
+        sed -En 's/.*\(([0-9]+)%\).*/\1/p'
+      }
+
+      # Push a value onto the wob overlay socket (0-100 bar).
+      wob() {
+        printf '%s\n' "$1" >"$XDG_RUNTIME_DIR/wob.sock"
+      }
+
+      case "''${1:-}" in
+        up)
+          wob "$(brightnessctl set +5% | percent)"
+          ;;
+        down)
+          # -n keeps a floor so the backlight never drops fully dark.
+          wob "$(brightnessctl -n set 5%- | percent)"
+          ;;
+        *)
+          echo "usage: ${pname} {up|down}" >&2
+          exit 1
+          ;;
+      esac
+    '';
+
+    meta.platforms = lib.platforms.linux;
+  }

--- a/packages/wob-volume.nix
+++ b/packages/wob-volume.nix
@@ -1,0 +1,56 @@
+{
+  pkgs,
+  pname,
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.writeShellApplication {
+    name = pname;
+
+    runtimeInputs = with pkgs; [
+      wireplumber
+      gnugrep
+      gnused
+    ];
+
+    text = ''
+      sink="@DEFAULT_AUDIO_SINK@"
+      source="@DEFAULT_AUDIO_SOURCE@"
+
+      # Push a value onto the wob overlay socket (0-100 bar).
+      wob() {
+        printf '%s\n' "$1" >"$XDG_RUNTIME_DIR/wob.sock"
+      }
+
+      level() {
+        wpctl get-volume "$sink" | sed 's/[^0-9]//g'
+      }
+
+      muted() {
+        wpctl get-volume "$sink" | grep -q MUTED
+      }
+
+      case "''${1:-}" in
+        up)
+          # When muted, show 0 without changing the level.
+          if muted; then wob 0; else wpctl set-volume "$sink" 2%+ && wob "$(level)"; fi
+          ;;
+        down)
+          if muted; then wob 0; else wpctl set-volume "$sink" 2%- && wob "$(level)"; fi
+          ;;
+        mute)
+          wpctl set-mute "$sink" toggle
+          if muted; then wob 0; else wob "$(level)"; fi
+          ;;
+        mic-mute)
+          wpctl set-mute "$source" toggle
+          ;;
+        *)
+          echo "usage: ${pname} {up|down|mute|mic-mute}" >&2
+          exit 1
+          ;;
+      esac
+    '';
+
+    meta.platforms = lib.platforms.linux;
+  }


### PR DESCRIPTION
## Summary

Extracts the inline `bash -c` command chains behind the niri audio/brightness keybinds into proper `packages/` scripts, so the logic is shellchecked, reusable, and out of the KDL string.

- **`wob-volume`** — `up` / `down` / `mute` / `mic-mute`. Preserves the original behavior: when muted, shows `0` on the wob overlay without changing the level; otherwise nudges ±2% and pushes the new level to `wob.sock`.
- **`wob-brightness`** — `up` / `down`. Keeps the original asymmetry (`set +5%` up, `-n set 5%-` down, with the min-value floor so the backlight never goes fully dark).
- **Media keys** — dropped the pointless `bash -c` wrapper; `XF86AudioPrev/Next/Play` now spawn `playerctl` directly via `lib.getExe` (hermetic path instead of relying on session `PATH`).

The `wob-` prefix makes the overlay integration obvious at the call site.

## Testing

- Both packages build → `writeShellApplication`'s shellcheck passes.
- neo builds fully, including the `niri-validate` derivation → the generated KDL is valid.
- `deadnix`, `statix`, and `alejandra` all clean.

Note: this intentionally changes derivations (inline shell → store paths), so it's behavior-equivalent rather than hash-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)