### PR TITLE
Extract inline scripts into packages/ (+ lock-screen fix)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,6 +19,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-img-blur
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-img-darken
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-lock-screen
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-lock-screen-timeout
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-mergify
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-qutebrowser-aerc
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screen-timeout
@@ -56,6 +57,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-img-blur
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-img-darken
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-lock-screen
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-lock-screen-timeout
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-mergify
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-qutebrowser-aerc
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screen-timeout

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-img-darken
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-lock-screen
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-mergify
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-qutebrowser-aerc
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-sleep-on-battery
@@ -53,6 +54,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-img-darken
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-lock-screen
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-mergify
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-qutebrowser-aerc
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-sleep-on-battery

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-lock-screen
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-mergify
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-qutebrowser-aerc
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screen-timeout
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-sleep-on-battery
@@ -57,6 +58,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-lock-screen
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-mergify
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-qutebrowser-aerc
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screen-timeout
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-sleep-on-battery

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-sleep-on-battery
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-available
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-system
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-system-hold
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wallpaper
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-email
@@ -60,6 +61,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-sleep-on-battery
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-available
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-system
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-system-hold
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wallpaper
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-email

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,6 +34,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-brightness
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume
@@ -72,6 +73,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-brightness
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-volume

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-sleep-on-battery
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-terminal-weather
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-available
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-system
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-update-system-hold
@@ -59,6 +60,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-annotate
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-screenshot-ocr
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-sleep-on-battery
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-terminal-weather
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-available
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-system
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-update-system-hold

--- a/modules/home/email/default.nix
+++ b/modules/home/email/default.nix
@@ -6,18 +6,6 @@
   ...
 }: let
   fmCfg = config.accounts.email.accounts.fastmail;
-  qutebrowser-aerc-config = pkgs.writeText "qutebrowser-aerc-config.py" ''
-    config.source("${config.xdg.configHome}/qutebrowser/config.py")
-    config.bind("q", "tab-close")
-  '';
-  qutebrowser-aerc = pkgs.writeShellScriptBin "qutebrowser-aerc" ''
-    exec ${lib.getExe pkgs.qutebrowser} \
-      --desktop-file-name qutebrowser-aerc \
-      --basedir "/tmp/qutebrowser-aerc-''${UID}" \
-      --config-py "${qutebrowser-aerc-config}" \
-      --target window \
-      "$@"
-  '';
 in {
   programs = {
     msmtp.enable = true;
@@ -33,8 +21,8 @@ in {
           "text/html" = "! html";
         };
         openers = {
-          "x-scheme-handler/http*" = "${lib.getExe qutebrowser-aerc} {}";
-          "text/html" = "${lib.getExe qutebrowser-aerc} {}";
+          "x-scheme-handler/http*" = "${lib.getExe pkgs.qutebrowser-aerc} {}";
+          "text/html" = "${lib.getExe pkgs.qutebrowser-aerc} {}";
         };
         ui = {
           index-columns = "flags:4,name<20%,labels<20%,subject,date>=";

--- a/modules/home/wlroots/services.nix
+++ b/modules/home/wlroots/services.nix
@@ -26,29 +26,13 @@
 
     swayidle = let
       lock = lib.getExe pkgs.lock-screen;
-
-      lockScreenTimeout = pkgs.writeShellApplication {
-        name = "lock-screen-timeout";
-
-        runtimeInputs = [
-          pkgs.procps
-          pkgs.screen-timeout
-        ];
-
-        text = ''
-          if pgrep swaylock
-          then
-            screen-timeout
-          fi
-        '';
-      };
     in {
       enable = true;
       events.before-sleep = lock;
       timeouts = [
         {
           timeout = 5;
-          command = lib.getExe lockScreenTimeout;
+          command = lib.getExe pkgs.lock-screen-timeout;
         }
         {
           timeout = 300;

--- a/modules/home/wlroots/services.nix
+++ b/modules/home/wlroots/services.nix
@@ -26,15 +26,13 @@
 
     swayidle = let
       lock = lib.getExe pkgs.lock-screen;
-      screenTimeout = pkgs.writeShellScriptBin "screen-timeout" "${lib.getExe pkgs.niri} msg action power-off-monitors";
 
       lockScreenTimeout = pkgs.writeShellApplication {
         name = "lock-screen-timeout";
 
-        runtimeInputs = with pkgs; [
-          procps
-          niri
-          screenTimeout
+        runtimeInputs = [
+          pkgs.procps
+          pkgs.screen-timeout
         ];
 
         text = ''
@@ -58,7 +56,7 @@
         }
         {
           timeout = 305;
-          command = lib.getExe screenTimeout;
+          command = lib.getExe pkgs.screen-timeout;
         }
         {
           timeout = 900;

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -130,7 +130,7 @@
           };
 
           "custom/ts" = lib.mkIf (hostName == "neo" || hostName == "morpheus") {
-            exec = "${lib.getExe pkgs.tailscale} status --peers --json | ${lib.getExe pkgs.jq} '.ExitNodeStatus.ID as $node_id | .Peer[] | select(.ID==$node_id) | .HostName' | tr -d '\"'";
+            exec = lib.getExe pkgs.wb-ts;
             interval = 3;
             format = "󰲐 {}";
             hide-empty-text = true;

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -150,26 +150,13 @@
             ];
           };
 
-          "custom/weather" = let
-            script = pkgs.writeShellApplication {
-              name = "terminal-weather";
-
-              runtimeInputs = [
-                pkgs.curl
-              ];
-
-              text = ''
-                curl https://wttr.in
-                read -r -p "Press Any Key to Continue"
-              '';
-            };
-          in {
+          "custom/weather" = {
             "format" = "{}°";
             "tooltip" = true;
             "interval" = 600;
             "exec" = "${lib.getExe pkgs.wttrbar} --nerd";
             "return-type" = "json";
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe script}";
+            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe pkgs.terminal-weather}";
           };
 
           "cava" = {

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -97,16 +97,7 @@
             on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e aerc";
           };
 
-          "custom/update" = let
-            switch = pkgs.writeShellApplication {
-              name = "update-system-hold";
-              runtimeInputs = [pkgs.update-system];
-              text = ''
-                update-system switch || true
-                read -n1 -rsp $'\nPress any key to close...\n'
-              '';
-            };
-          in {
+          "custom/update" = {
             exec = lib.getExe pkgs.update-available;
             interval = 300;
             return-type = "json";
@@ -118,7 +109,7 @@
             };
             # Launch as a transient unit so it lives in its own cgroup and
             # survives waybar restarts (which would otherwise kill children).
-            on-click = "${pkgs.systemd}/bin/systemd-run --user --quiet --collect -- ${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe switch}";
+            on-click = "${pkgs.systemd}/bin/systemd-run --user --quiet --collect -- ${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe pkgs.update-system-hold}";
           };
 
           "custom/cast" = {

--- a/packages/lock-screen-timeout.nix
+++ b/packages/lock-screen-timeout.nix
@@ -1,0 +1,24 @@
+{
+  pkgs,
+  perSystem,
+  pname,
+  ...
+}:
+# Power off monitors on idle, but only while the screen is locked.
+pkgs.writeShellApplication {
+  name = pname;
+
+  runtimeInputs = [
+    pkgs.procps
+    perSystem.self.screen-timeout
+  ];
+
+  text = ''
+    if pgrep swaylock
+    then
+      screen-timeout
+    fi
+  '';
+
+  meta.platforms = pkgs.lib.platforms.linux;
+}

--- a/packages/lock-screen.nix
+++ b/packages/lock-screen.nix
@@ -8,6 +8,7 @@ in
     name = pname;
 
     runtimeInputs = with pkgs; [
+      coreutils
       niri
       jq
       grim

--- a/packages/qutebrowser-aerc.nix
+++ b/packages/qutebrowser-aerc.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  pname,
+}: let
+  inherit (pkgs) lib;
+
+  config-py = pkgs.writeText "${pname}-config.py" ''
+    import os
+
+    # Reuse the user's main qutebrowser config in this throwaway instance.
+    config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+    config.source(os.path.join(config_home, "qutebrowser", "config.py"))
+    config.bind("q", "tab-close")
+  '';
+in
+  pkgs.writeShellApplication {
+    name = pname;
+
+    text = ''
+      exec ${lib.getExe pkgs.qutebrowser} \
+        --desktop-file-name ${pname} \
+        --basedir "/tmp/${pname}-''${UID}" \
+        --config-py "${config-py}" \
+        --target window \
+        "$@"
+    '';
+
+    meta.platforms = lib.platforms.linux;
+  }

--- a/packages/screen-timeout.nix
+++ b/packages/screen-timeout.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  pname,
+}:
+# Power off all monitors via niri (used as a swayidle timeout / lock helper).
+pkgs.writeShellApplication {
+  name = pname;
+
+  runtimeInputs = [pkgs.niri];
+
+  text = ''
+    niri msg action power-off-monitors
+  '';
+
+  meta.platforms = pkgs.lib.platforms.linux;
+}

--- a/packages/terminal-weather.nix
+++ b/packages/terminal-weather.nix
@@ -1,0 +1,17 @@
+{
+  pkgs,
+  pname,
+}:
+# Show the weather in a terminal and wait for a keypress (waybar on-click).
+pkgs.writeShellApplication {
+  name = pname;
+
+  runtimeInputs = [pkgs.curl];
+
+  text = ''
+    curl https://wttr.in
+    read -r -p "Press Any Key to Continue"
+  '';
+
+  meta.platforms = pkgs.lib.platforms.linux;
+}

--- a/packages/update-system-hold.nix
+++ b/packages/update-system-hold.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  perSystem,
+  pname,
+  ...
+}:
+# Runs a system update, then holds the terminal open so the output stays
+# visible after it finishes (used as a waybar on-click).
+pkgs.writeShellApplication {
+  name = pname;
+
+  runtimeInputs = [perSystem.self.update-system];
+
+  text = ''
+    update-system switch || true
+    read -n1 -rsp $'\nPress any key to close...\n'
+  '';
+
+  meta.platforms = pkgs.lib.platforms.linux;
+}

--- a/packages/wb-ts.nix
+++ b/packages/wb-ts.nix
@@ -1,0 +1,23 @@
+{
+  pkgs,
+  pname,
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.writeShellApplication {
+    name = pname;
+
+    runtimeInputs = with pkgs; [
+      tailscale
+      jq
+    ];
+
+    # Print the hostname of the active Tailscale exit node (empty if none).
+    text = ''
+      tailscale status --peers --json \
+        | jq '.ExitNodeStatus.ID as $node_id | .Peer[] | select(.ID==$node_id) | .HostName' \
+        | tr -d '"'
+    '';
+
+    meta.platforms = lib.platforms.linux;
+  }


### PR DESCRIPTION
## Summary

Lifts inline scripts/command-chains out of the home modules into standalone `packages/`, so they're shellchecked, reusable, and out of module `let`-bindings / config strings. Each package is its own commit, and every package-adding commit also regenerates `.mergify.yml` (per the documented rule).

Extracted:
- **`qutebrowser-aerc`** (from the email module) — the aerc browser wrapper + its throwaway config. The config now resolves the user's main qutebrowser config via `$XDG_CONFIG_HOME` (fallback `~/.config`) at runtime instead of a baked eval-time path.
- **`update-system-hold`** (waybar custom/update) — hash-identical to the old inline derivation.
- **`terminal-weather`** (waybar custom/weather) — hash-identical to the old inline derivation.
- **`screen-timeout`** (swayidle) — converted `writeShellScriptBin` → `writeShellApplication` for shellcheck/consistency.
- **`lock-screen-timeout`** (swayidle) — depends on `screen-timeout` via `perSystem.self`.
- **`wb-ts`** (waybar custom/ts) — the `tailscale status | jq | tr` pipeline, matching the existing `wb-*` convention.

## Bug fix (separate commit)

- **`lock-screen`: add `coreutils` to `runtimeInputs`.** It used `mktemp`/`rm` from the ambient PATH, which works interactively but not under swayidle (bash-only service PATH) — the missing `mktemp` tripped the ERR trap and fell back to a plain swaylock with no blurred screenshot. Declaring `coreutils` fixes swayidle-triggered locks.

## Testing

- All new packages build (shellcheck passes via `writeShellApplication`).
- neo + morpheus build fully (email module, waybar, swayidle, `niri-validate`, and `wb-ts` on morpheus).
- `checks.x86_64-linux.mergify` passes; deadnix/statix/alejandra clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)