### PR TITLE
Harden shell packages + add parser tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,10 +34,14 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan-average
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-brightness
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-brightness-percent
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume-level
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume-muted
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.devshell-default
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.git-hooks
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.hydra-spec
@@ -73,8 +77,12 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-cast
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan-average
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-brightness
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-brightness-percent
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-volume
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-volume-level
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-volume-muted
   name: Automatically merge dependabot updates

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -18,6 +18,11 @@
         if hostName == "morpheus"
         then 144
         else 60;
+
+      # Run a command in a floating "hover" terminal (waybar on-click).
+      hover = cmd: "${lib.getExe config.programs.alacritty.package} --class hover -e ${cmd}";
+      # Open bottom on a given default widget in a hover terminal.
+      btm = widget: hover "${lib.getExe config.programs.bottom.package} --default_widget_type ${widget} -e";
     in {
       enable = true;
       systemd.enable = true;
@@ -94,7 +99,7 @@
             return-type = "json";
             format = "󰇮 {}";
             hide-empty-text = true;
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e aerc";
+            on-click = hover "aerc";
           };
 
           "custom/update" = {
@@ -109,7 +114,7 @@
             };
             # Launch as a transient unit so it lives in its own cgroup and
             # survives waybar restarts (which would otherwise kill children).
-            on-click = "${pkgs.systemd}/bin/systemd-run --user --quiet --collect -- ${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe pkgs.update-system-hold}";
+            on-click = "${pkgs.systemd}/bin/systemd-run --user --quiet --collect -- ${hover "${lib.getExe pkgs.update-system-hold}"}";
           };
 
           "custom/cast" = {
@@ -126,7 +131,7 @@
             format = "{}";
             return-type = "json";
             hide-empty-text = true;
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe config.programs.bottom.package} --default_widget_type temp -e";
+            on-click = btm "temp";
           };
 
           "custom/ts" = lib.mkIf (hostName == "neo" || hostName == "morpheus") {
@@ -156,7 +161,7 @@
             "interval" = 600;
             "exec" = "${lib.getExe pkgs.wttrbar} --nerd";
             "return-type" = "json";
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe pkgs.terminal-weather}";
+            on-click = hover "${lib.getExe pkgs.terminal-weather}";
           };
 
           "cava" = {
@@ -221,14 +226,14 @@
             format = " {usage}%";
             tooltip = true;
             interval = 3;
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe config.programs.bottom.package} --default_widget_type cpu -e";
+            on-click = btm "cpu";
           };
 
           "memory" = {
             format = " {used:0.1f} GiB";
             tooltip-format = "Memory {used:0.1f} GiB / {total:0.1f} GiB\nSwap: {swapUsed:0.1f} GiB / {swapTotal:0.1f} GiB";
             interval = 3;
-            on-click = "${lib.getExe config.programs.alacritty.package} --class hover -e ${lib.getExe config.programs.bottom.package} --default_widget_type mem -e";
+            on-click = btm "mem";
           };
 
           "backlight" = {

--- a/packages/fastmail-unread.nix
+++ b/packages/fastmail-unread.nix
@@ -8,6 +8,7 @@ in
     name = pname;
 
     runtimeInputs = with pkgs; [
+      coreutils
       curl
       jq
     ];

--- a/packages/img-blur.nix
+++ b/packages/img-blur.nix
@@ -5,7 +5,7 @@
 pkgs.writeShellApplication {
   name = pname;
 
-  runtimeInputs = [pkgs.vips];
+  runtimeInputs = with pkgs; [coreutils vips];
 
   text = ''
     name=$(basename "$1")

--- a/packages/img-darken.nix
+++ b/packages/img-darken.nix
@@ -5,7 +5,7 @@
 pkgs.writeShellApplication {
   name = pname;
 
-  runtimeInputs = [pkgs.vips];
+  runtimeInputs = with pkgs; [coreutils vips];
 
   text = ''
     name=$(basename "$1")

--- a/packages/lock-screen.nix
+++ b/packages/lock-screen.nix
@@ -18,7 +18,9 @@ in
     ];
 
     text = ''
-      trap "swaylock -fF" ERR INT
+      # Fall back to a plain lock if screenshot/blur setup fails, but log it
+      # first so the failure is visible in the journal instead of silent.
+      trap 'echo "lock-screen: screenshot setup failed, falling back to plain lock" >&2; swaylock -fF' ERR INT
 
       scratch=$(mktemp -d -t lockscreenshot.XXX)
       trap 'rm -rf "''${scratch}"' EXIT

--- a/packages/screenshot-ocr.nix
+++ b/packages/screenshot-ocr.nix
@@ -8,6 +8,7 @@ in
     name = pname;
 
     runtimeInputs = with pkgs; [
+      coreutils
       grim
       slurp
       tesseract

--- a/packages/wb-fan.nix
+++ b/packages/wb-fan.nix
@@ -3,8 +3,8 @@
   pname,
 }: let
   inherit (pkgs) lib;
-in
-  pkgs.writeShellApplication {
+
+  package = pkgs.writeShellApplication {
     name = pname;
 
     runtimeInputs = with pkgs; [
@@ -15,7 +15,10 @@ in
     bashOptions = [];
 
     text = ''
-      sensors -j | jq --unbuffered -c '
+      # sensors is overridable so the jq filter can be tested with a stub.
+      sensors="''${SENSORS:-sensors}"
+
+      "$sensors" -j | jq --unbuffered -c '
         [to_entries[]
           | {controller: .key} as $entry
           | .value | to_entries[]
@@ -41,4 +44,19 @@ in
     '';
 
     meta.platforms = lib.platforms.linux;
-  }
+
+    passthru.tests = {
+      # Two fans at 1000 and 2000 RPM should report the floored average (1500).
+      average = pkgs.runCommandLocal "${pname}-average" {} ''
+        export SENSORS=${pkgs.writeShellScript "sensors-stub" ''
+          echo '{"nct6798-isa-0290":{"fan1":{"fan1_input":1000.0},"fan2":{"fan2_input":2000.0}}}'
+        ''}
+        got=$(${lib.getExe package})
+        echo "$got" | grep -q 'fan1: 1000 RPM' || { echo "bad tooltip: $got" >&2; exit 1; }
+        echo "$got" | grep -q '1500' || { echo "wrong average: $got" >&2; exit 1; }
+        touch "$out"
+      '';
+    };
+  };
+in
+  package

--- a/packages/wb-ts.nix
+++ b/packages/wb-ts.nix
@@ -8,6 +8,7 @@ in
     name = pname;
 
     runtimeInputs = with pkgs; [
+      coreutils
       tailscale
       jq
     ];

--- a/packages/webcam-picker.nix
+++ b/packages/webcam-picker.nix
@@ -7,7 +7,7 @@ in
   pkgs.writeShellApplication {
     name = pname;
 
-    runtimeInputs = with pkgs; [v4l-utils fuzzel];
+    runtimeInputs = with pkgs; [coreutils v4l-utils fuzzel];
 
     text = ''
       declare -A cam_to_dev=()

--- a/packages/wob-brightness.nix
+++ b/packages/wob-brightness.nix
@@ -3,8 +3,8 @@
   pname,
 }: let
   inherit (pkgs) lib;
-in
-  pkgs.writeShellApplication {
+
+  package = pkgs.writeShellApplication {
     name = pname;
 
     runtimeInputs = with pkgs; [
@@ -13,6 +13,9 @@ in
     ];
 
     text = ''
+      # brightnessctl is overridable so the parser can be tested with a stub.
+      brightnessctl="''${BRIGHTNESSCTL:-brightnessctl}"
+
       # Pull the "(NN%)" percentage out of brightnessctl's output.
       percent() {
         sed -En 's/.*\(([0-9]+)%\).*/\1/p'
@@ -25,11 +28,11 @@ in
 
       case "''${1:-}" in
         up)
-          wob "$(brightnessctl set +5% | percent)"
+          wob "$("$brightnessctl" set +5% | percent)"
           ;;
         down)
           # -n keeps a floor so the backlight never drops fully dark.
-          wob "$(brightnessctl -n set 5%- | percent)"
+          wob "$("$brightnessctl" -n set 5%- | percent)"
           ;;
         *)
           echo "usage: ${pname} {up|down}" >&2
@@ -39,4 +42,26 @@ in
     '';
 
     meta.platforms = lib.platforms.linux;
-  }
+
+    passthru.tests = {
+      # Feed a canned brightnessctl line and assert the percentage lands on wob.
+      percent = pkgs.runCommandLocal "${pname}-percent" {} ''
+        export XDG_RUNTIME_DIR="$PWD"
+        export BRIGHTNESSCTL=${pkgs.writeShellScript "brightnessctl-stub" ''
+          echo "Current brightness: 96 (37%)"
+        ''}
+
+        for dir in up down; do
+          ${lib.getExe package} "$dir"
+          got=$(cat "$XDG_RUNTIME_DIR/wob.sock")
+          [ "$got" = "37" ] || {
+            echo "$dir: expected 37, got '$got'" >&2
+            exit 1
+          }
+        done
+        touch "$out"
+      '';
+    };
+  };
+in
+  package

--- a/packages/wob-volume.nix
+++ b/packages/wob-volume.nix
@@ -3,8 +3,8 @@
   pname,
 }: let
   inherit (pkgs) lib;
-in
-  pkgs.writeShellApplication {
+
+  package = pkgs.writeShellApplication {
     name = pname;
 
     runtimeInputs = with pkgs; [
@@ -17,33 +17,36 @@ in
       sink="@DEFAULT_AUDIO_SINK@"
       source="@DEFAULT_AUDIO_SOURCE@"
 
+      # wpctl is overridable so the parser can be tested with a stub.
+      wpctl="''${WPCTL:-wpctl}"
+
       # Push a value onto the wob overlay socket (0-100 bar).
       wob() {
         printf '%s\n' "$1" >"$XDG_RUNTIME_DIR/wob.sock"
       }
 
       level() {
-        wpctl get-volume "$sink" | sed 's/[^0-9]//g'
+        "$wpctl" get-volume "$sink" | sed 's/[^0-9]//g'
       }
 
       muted() {
-        wpctl get-volume "$sink" | grep -q MUTED
+        "$wpctl" get-volume "$sink" | grep -q MUTED
       }
 
       case "''${1:-}" in
         up)
           # When muted, show 0 without changing the level.
-          if muted; then wob 0; else wpctl set-volume "$sink" 2%+ && wob "$(level)"; fi
+          if muted; then wob 0; else "$wpctl" set-volume "$sink" 2%+ && wob "$(level)"; fi
           ;;
         down)
-          if muted; then wob 0; else wpctl set-volume "$sink" 2%- && wob "$(level)"; fi
+          if muted; then wob 0; else "$wpctl" set-volume "$sink" 2%- && wob "$(level)"; fi
           ;;
         mute)
-          wpctl set-mute "$sink" toggle
+          "$wpctl" set-mute "$sink" toggle
           if muted; then wob 0; else wob "$(level)"; fi
           ;;
         mic-mute)
-          wpctl set-mute "$source" toggle
+          "$wpctl" set-mute "$source" toggle
           ;;
         *)
           echo "usage: ${pname} {up|down|mute|mic-mute}" >&2
@@ -53,4 +56,34 @@ in
     '';
 
     meta.platforms = lib.platforms.linux;
-  }
+
+    passthru.tests = let
+      # Stub wpctl: report a fixed get-volume line, ignore set-* commands.
+      stub = getVolume:
+        pkgs.writeShellScript "wpctl-stub" ''
+          case "$1" in
+            get-volume) echo "${getVolume}" ;;
+            *) ;;
+          esac
+        '';
+      run = name: getVolume: arg: expected:
+        pkgs.runCommandLocal "${pname}-${name}" {} ''
+          export XDG_RUNTIME_DIR="$PWD"
+          export WPCTL=${stub getVolume}
+          ${lib.getExe package} ${arg}
+          got=$(cat "$XDG_RUNTIME_DIR/wob.sock")
+          [ "$got" = "${expected}" ] || {
+            echo "expected '${expected}', got '$got'" >&2
+            exit 1
+          }
+          touch "$out"
+        '';
+    in {
+      # Unmuted: raising reports the parsed numeric level.
+      level = run "level" "Volume: 0.50" "up" "050";
+      # Muted: raising reports 0 without touching the level.
+      muted = run "muted" "Volume: 0.50 [MUTED]" "up" "0";
+    };
+  };
+in
+  package


### PR DESCRIPTION
## Summary

Follow-ups after the `lock-screen`/swayidle PATH bug — hardening the shell packages against the same class of failure, improving diagnosability, a small DRY, and test coverage for the fragile parsers. One commit per change.

- **Declare `coreutils` in shell packages that relied on ambient PATH** — `fastmail-unread`, `img-blur`, `img-darken`, `screenshot-ocr`, `webcam-picker`, `wb-ts` all used coreutils commands (mktemp/rm/basename/mv/cat/tr/sort) without declaring them. They work today only because their invokers (waybar, niri spawns, lock-screen) inherit a PATH with coreutils — the same latent fragility that broke `lock-screen` under swayidle's bash-only service PATH. Now hermetic.
- **`lock-screen`: log before the plain-lock fallback** — the ERR trap silently ran `swaylock -fF` on any failure, which is why the missing-coreutils bug looked like "the blur just doesn't work". It now emits a line to stderr (captured by the journal) first.
- **DRY the hover-terminal on-clicks in waybar** — factor the repeated `alacritty --class hover -e <cmd>` into a `hover` helper (and the three `bottom` on-clicks into `btm`). Generated waybar config is byte-unchanged.
- **Parser tests for `wob-volume` / `wob-brightness` / `wb-fan`** — add an overridable env seam (`WPCTL` / `BRIGHTNESSCTL` / `SENSORS`) so the external tool can be stubbed, then VM-free `runCommand` `passthru.tests` that feed canned output and assert the parsed result. `.mergify.yml` regenerated for the new per-test checks.

## Testing

- All packages build (shellcheck passes); neo builds fully (niri-validate + waybar) after each change.
- New tests pass: `wob-volume` level→`050` / muted→`0`, `wob-brightness` `(37%)`→`37`, `wb-fan` two fans→`1500`.
- `checks.x86_64-linux.mergify` passes; new `pkgs-*` test checks present on both arches.
- deadnix/statix/treefmt clean on every commit.

## Notes

- The env seam is needed because `writeShellApplication` puts `runtimeInputs` ahead of `$PATH`, so a stub can't win via PATH. Defaults are unchanged in production.
- Tests use `runCommand` rather than `nixosTest` (which `battery-status` uses) since these are pure parsers with no hardware/kernel dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)