### PR TITLE
Harden the immich-stack systemd unit

### DIFF
--- a/modules/nixos/immich/default.nix
+++ b/modules/nixos/immich/default.nix
@@ -18,13 +18,47 @@
 
   systemd = {
     services.immich-stack = {
-      serviceConfig = {
-        EnvironmentFile = config.age.secrets.immich.path;
-      };
       description = "Stacking Raw and JPG Photos in Immich";
       script = ''
         ${lib.getExe pkgs.immich-go} stack --server=http://localhost:${toString config.services.immich.port} --api-key="$IMMICH_API_KEY" --manage-raw-jpeg StackCoverJPG
       '';
+      serviceConfig = {
+        Type = "oneshot";
+        EnvironmentFile = config.age.secrets.immich.path;
+
+        # Run as a transient unprivileged user with its own writable state dir
+        # for immich-go's cache/logs (WorkingDirectory + HOME point at it, so
+        # nothing needs to write outside the sandbox).
+        DynamicUser = true;
+        StateDirectory = "immich-stack";
+        WorkingDirectory = "%S/immich-stack";
+        Environment = "HOME=%S/immich-stack";
+
+        # This only needs to reach the local immich API over TCP.
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictAddressFamilies = ["AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK"];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = ["@system-service"];
+        SystemCallErrorNumber = "EPERM";
+      };
     };
     timers.immich-stack = {
       wantedBy = ["timers.target"];


### PR DESCRIPTION
## What

Sandboxes the daily `immich-stack` job (`modules/nixos/immich/default.nix`), which currently runs **unconfined as root** with just an `EnvironmentFile`.

Now it runs as a transient `DynamicUser` under a strict systemd sandbox:
- `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `PrivateDevices`, `ProtectProc=invisible`, kernel/clock/cgroup protections
- `SystemCallFilter=@system-service`, `CapabilityBoundingSet=` (drop all caps), `NoNewPrivileges`, `MemoryDenyWriteExecute`, `LockPersonality`
- `RestrictAddressFamilies` limited to what immich-go needs to reach the local API (`AF_UNIX AF_INET AF_INET6 AF_NETLINK`)
- A `StateDirectory` with matching `HOME`/`WorkingDirectory` so immich-go still has a writable place for its cache/logs
- `Type=oneshot` to match its timer-driven batch nature

## Why

Pure hardening win, no closure cost — brings this unit in line with the `attic-watch` unit's existing `DynamicUser`/sandbox pattern.

## Verification

- `nixos-rebuild build --flake .#morpheus` succeeds locally; alejandra/statix/deadnix clean.
- ⚠️ **Runtime not exercised by Hydra** (it builds the closure, doesn't run the timer). After merge, confirm the next daily run (or `systemctl start immich-stack`) still completes — the main things to watch are immich-go's file writes landing in the `StateDirectory` and the localhost API connection surviving the syscall/address-family filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)