### PR TITLE
Add systemd OnFailure e-mail notifications

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,6 +43,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume-level
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-volume-muted
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.devshell-default
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.failure-notify
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.git-hooks
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.hydra-spec
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.mergify

--- a/checks/failure-notify.nix
+++ b/checks/failure-notify.nix
@@ -1,0 +1,61 @@
+# Exercises the failure-notify module end to end: a deliberately failing unit
+# should trigger the OnFailure= handler, which renders and "sends" an e-mail.
+# The delivery command is overridden to capture the message to a file, which is
+# then shipped as a build artifact (failure-notify-sample.eml in $out) so the
+# rendered mail can be inspected.
+{
+  flake,
+  pkgs,
+  ...
+}:
+pkgs.testers.nixosTest {
+  name = "failure-notify";
+
+  nodes.machine = {
+    imports = [flake.nixosModules.failure-notify];
+
+    networking.domain = "example.test";
+
+    # A unit guaranteed to fail, wired through the notifier.
+    systemd.services.canary = {
+      description = "Deliberately failing unit for the failure-notify test";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.coreutils}/bin/false";
+      };
+    };
+
+    services.failureNotify = {
+      enable = true;
+      recipient = "ops@example.test";
+      units = ["canary"];
+      # Capture the rendered message instead of sending it over SMTP.
+      sendmailCommand = "${pkgs.coreutils}/bin/tee /var/lib/failure-notify-sample.eml";
+    };
+
+    system.stateVersion = "25.11";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # Trigger the failure; the unit is expected to fail, which fires the
+    # OnFailure= handler asynchronously.
+    machine.fail("systemctl start canary.service")
+
+    # Wait for the handler to render and capture the message.
+    machine.wait_until_succeeds("test -s /var/lib/failure-notify-sample.eml")
+
+    email = machine.succeed("cat /var/lib/failure-notify-sample.eml")
+    assert "Subject: [machine] Unit failed: canary.service" in email, email
+    assert "To: ops@example.test" in email, email
+    assert "entered a failed state" in email, email
+    assert "canary.service" in email, email
+
+    # Ship the rendered e-mail as a build artifact.
+    machine.copy_from_vm("/var/lib/failure-notify-sample.eml", "")
+  '';
+
+  # VM test only makes sense on x86_64; keep it off emulated aarch64 builders.
+  meta.platforms = ["x86_64-linux"];
+}

--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -38,9 +38,20 @@
       lubelogger
       asus-desktop
       zfs
+      failure-notify
     ]);
 
   services.lyndenoAcme.enable = true;
+
+  services.failureNotify = {
+    enable = true;
+    units = [
+      "borgbackup-job-borgbase"
+      "immich-stack"
+      "nix-gc"
+      "nixos-upgrade"
+    ];
+  };
 
   age = {
     secrets = {

--- a/modules/nixos/failure-notify/default.nix
+++ b/modules/nixos/failure-notify/default.nix
@@ -6,12 +6,16 @@
 }: let
   cfg = config.services.failureNotify;
 
+  # Default delivery: hand the full RFC5322 message to msmtp on stdin and let
+  # it read the recipients from the headers (-t).
+  defaultSendmail = "${lib.getExe pkgs.msmtp} -t";
+
   # Instanced handler: `notify-email@<failed-unit>` mails a short report about
   # the unit that failed. Triggered via OnFailure= on the units below.
   notifyScript = pkgs.writeShellScript "notify-email" ''
     set -eu
     unit="$1"
-    ${lib.getExe pkgs.msmtp} -t <<EOF
+    ${cfg.sendmailCommand} <<EOF
     To: ${cfg.recipient}
     From: systemd <${cfg.from}>
     Subject: [${config.networking.hostName}] Unit failed: $unit
@@ -52,13 +56,25 @@ in {
         the host.
       '';
     };
+
+    sendmailCommand = lib.mkOption {
+      type = lib.types.str;
+      default = defaultSendmail;
+      defaultText = lib.literalExpression ''"''${lib.getExe pkgs.msmtp} -t"'';
+      description = ''
+        Command handed the full message on stdin. Defaults to msmtp; override
+        it to deliver the message elsewhere (e.g. capture it to a file in a
+        test).
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = config.programs.msmtp.enable;
-        message = "services.failureNotify requires programs.msmtp to send mail.";
+        # Only the default delivery path needs msmtp.
+        assertion = cfg.sendmailCommand != defaultSendmail || config.programs.msmtp.enable;
+        message = "services.failureNotify requires programs.msmtp to send mail (or a custom sendmailCommand).";
       }
     ];
 

--- a/modules/nixos/failure-notify/default.nix
+++ b/modules/nixos/failure-notify/default.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.failureNotify;
+
+  # Instanced handler: `notify-email@<failed-unit>` mails a short report about
+  # the unit that failed. Triggered via OnFailure= on the units below.
+  notifyScript = pkgs.writeShellScript "notify-email" ''
+    set -eu
+    unit="$1"
+    ${lib.getExe pkgs.msmtp} -t <<EOF
+    To: ${cfg.recipient}
+    From: systemd <${cfg.from}>
+    Subject: [${config.networking.hostName}] Unit failed: $unit
+
+    The systemd unit "$unit" entered a failed state on ${config.networking.hostName} at $(date).
+
+    ---- systemctl status ----
+    $(${pkgs.systemd}/bin/systemctl status --full --lines=50 --no-pager "$unit" 2>&1 || true)
+
+    ---- journal (last 50 lines) ----
+    $(${pkgs.systemd}/bin/journalctl -u "$unit" -n 50 --no-pager 2>&1 || true)
+    EOF
+  '';
+in {
+  options.services.failureNotify = {
+    enable = lib.mkEnableOption "e-mail notifications when systemd units fail";
+
+    recipient = lib.mkOption {
+      type = lib.types.str;
+      default = "lsanche@lyndeno.ca";
+      description = "Address that failure notifications are sent to.";
+    };
+
+    from = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.networking.hostName}@system.${config.networking.domain}";
+      description = "Envelope/From address for notifications.";
+    };
+
+    units = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["borgbackup-job-borgbase" "nix-gc"];
+      description = ''
+        Units to attach an `OnFailure=` handler to, named without the
+        `.service` suffix. Each will trigger `notify-email@<unit>` when it
+        enters the failed state. Names must match units that already exist on
+        the host.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.programs.msmtp.enable;
+        message = "services.failureNotify requires programs.msmtp to send mail.";
+      }
+    ];
+
+    systemd.services = lib.mkMerge [
+      {
+        "notify-email@" = {
+          description = "Send failure notification e-mail for %i";
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${notifyScript} %i";
+          };
+        };
+      }
+      # Attach the handler to each target. `%n` expands to the full failing
+      # unit name at runtime, so the report is about the right unit.
+      (lib.genAttrs cfg.units (_: {
+        unitConfig.OnFailure = "notify-email@%n.service";
+      }))
+    ];
+  };
+}


### PR DESCRIPTION
## What

New module `modules/nixos/failure-notify` exposing `services.failureNotify`:

- An instanced handler `notify-email@<unit>.service` that mails a report (subject `[<host>] Unit failed: <unit>`, body = `systemctl status` + last 50 journal lines) via the existing `msmtp` setup.
- An `OnFailure=notify-email@%n.service` hook attached to a configurable `units` list.
- An assertion that `programs.msmtp` is enabled.

Enabled on **morpheus** for the unattended jobs: `borgbackup-job-borgbase`, `immich-stack`, `nix-gc`, `nixos-upgrade`.

## Why

Routes failures of unattended jobs through systemd's native `OnFailure=` mechanism instead of each job growing its own notification logic. Same spirit as smartd's mail, but generic and systemd-integrated.

## Notes / verification

- `nixos-rebuild build --flake .#morpheus` succeeds; verified the generated units — all four targets carry `OnFailure=notify-email@%n.service` and `notify-email@.service` is present with the correct `ExecStart`. alejandra/statix/deadnix clean.
- The handler runs as root so it can read the (root-owned) msmtp password secret and the failed unit's journal.
- ⚠️ **Not runtime-exercised by Hydra.** To smoke-test after merge: `systemd-run --unit=test-fail-$RANDOM /bin/false` won't trigger it, but forcing one of the wired units to fail (or temporarily adding a bogus unit) will confirm mail delivery end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)