### PR TITLE
Tune systemd-oomd on morpheus

### DIFF
--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -82,6 +82,25 @@
 
   zramSwap.enable = true;
 
+  # systemd-oomd: on this build/service host a runaway nix build can drive the
+  # machine into swap thrash before the kernel OOM killer reacts. Let oomd act
+  # first, based on cgroup pressure/swap, so it kills the offending cgroup
+  # cleanly. Monitor the root slice (swap exhaustion, incl. zram above) plus
+  # the system and user slices (sustained memory pressure). Tradeoff: under
+  # heavy pressure oomd may kill a well-behaved service in system.slice, not
+  # just the build — acceptable here since everything is restartable.
+  systemd.oomd = {
+    enable = true;
+    enableRootSlice = true;
+    enableSystemSlice = true;
+    enableUserSlices = true;
+    extraConfig = {
+      # Require pressure to persist before acting, to avoid twitchy kills
+      # during normal build spikes.
+      DefaultMemoryPressureDurationSec = "20s";
+    };
+  };
+
   system = {
     autoUpgrade = {
       enable = true;


### PR DESCRIPTION
## What

Configures `systemd.oomd` on **morpheus**:

- `enableRootSlice` + `enableSystemSlice` + `enableUserSlices` → `ManagedOOMMemoryPressure=kill` (80% limit) on `-.slice`, `system.slice`, and user slices.
- `DefaultMemoryPressureDurationSec = "20s"` so pressure must persist before oomd acts.

## Why

oomd is enabled by default but does nothing without slice monitoring. On a build/service host a runaway `nix` build can drive the machine into swap thrash (incl. zram) before the kernel OOM killer reacts. With this, oomd kills the offending cgroup cleanly, based on cgroup pressure/swap, first.

## Tradeoff (your call to accept)

`enableSystemSlice` means that under sustained pressure oomd may kill **whichever cgroup in `system.slice` is the heaviest** — which could be a well-behaved service (postgresql, immich, plex) rather than the build itself. I judged that acceptable here since everything on morpheus is restartable, and documented it inline. If you'd rather protect services, we can drop to root-slice/swap-only monitoring — say the word and I'll adjust this PR.

## Verification

- `nixos-rebuild build --flake .#morpheus` succeeds; verified the drop-ins: `-.slice` and `system.slice` carry `ManagedOOMMemoryPressure=kill` / `ManagedOOMMemoryPressureLimit=80%`, `oomd.conf` has `DefaultMemoryPressureDurationSec=20s`, and `systemd-oomd.service` is enabled. alejandra/statix/deadnix clean.
- ⚠️ **OOM behavior is not exercised by Hydra** (build-only). Real behavior only shows under actual memory pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)