### PR TITLE
Gate laptop nix maintenance on AC power

### DIFF
--- a/modules/nixos/laptop/default.nix
+++ b/modules/nixos/laptop/default.nix
@@ -1,6 +1,15 @@
 {
-  systemd.sleep.settings.Sleep = {
-    HibernateDelaySec = "2h";
+  systemd = {
+    sleep.settings.Sleep = {
+      HibernateDelaySec = "2h";
+    };
+
+    # Skip unattended nix maintenance while on battery; the timers will run
+    # the next time the job fires on AC. (Borg already gates on AC per-host.)
+    services = {
+      nix-gc.unitConfig.ConditionACPower = true;
+      nix-optimise.unitConfig.ConditionACPower = true;
+    };
   };
 
   services = {


### PR DESCRIPTION
## What

Adds `ConditionACPower=true` to the `nix-gc` and `nix-optimise` units in the `laptop` module (currently only neo).

## Why

Unattended nix maintenance (GC, store optimise) is disk/CPU heavy and pointless to run on battery. This mirrors the existing per-host borgbackup AC gating (`borgbackup-job-borgbase.unitConfig.ConditionACPower`). Timers still fire on schedule; the job simply no-ops (skipped, not failed) while on battery and runs the next time it fires on AC.

## Verification

- `nixos-rebuild build --flake .#neo` succeeds; verified both `nix-gc.service` and `nix-optimise.service` carry `ConditionACPower=true`. alejandra/statix/deadnix clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)