### PR TITLE
Add gpu-coredump module to capture DRM device coredumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -46,6 +46,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.devshell-default
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.failure-notify
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.git-hooks
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.gpu-coredump
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.hydra-spec
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.mergify
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.nixos-morpheus

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ pubKeys.nix                       # SSH/Age public keys for hosts and users
 | `failure-notify` | E-mails a report when a systemd unit enters the failed state |
 | `firefly` | Firefly III personal finance manager |
 | `gaming` | Steam, Gamescope and gaming applications |
+| `gpu-coredump` | Saves DRM/amdgpu device coredumps before the kernel expires them |
 | `home-assistant` | Home Assistant home automation |
 | `host-meta` | Declares the hostMeta options consumed by the README generator |
 | `hydra` | Hydra continuous-integration server |

--- a/checks/gpu-coredump.nix
+++ b/checks/gpu-coredump.nix
@@ -1,0 +1,65 @@
+# Exercises the gpu-coredump module. A real devcoredump can only be produced by
+# a driver hitting a hardware hang, which a VM cannot stage, so the module's
+# sourceDir is pointed at a fixture directory standing in for sysfs. That covers
+# everything downstream of the udev event: the capture service, the compressed
+# dump, the kernel log sidecar, and retention pruning.
+{
+  flake,
+  pkgs,
+  ...
+}:
+pkgs.testers.nixosTest {
+  name = "gpu-coredump";
+
+  nodes.machine = {
+    imports = [flake.nixosModules.gpu-coredump];
+
+    services.gpuCoredump = {
+      enable = true;
+      sourceDir = "/run/fake-devcoredump";
+      maxDumps = 2;
+    };
+
+    system.stateVersion = "25.11";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # Stand in for the sysfs node the kernel would create on a GPU hang.
+    machine.succeed("mkdir -p /run/fake-devcoredump/devcd0")
+    machine.succeed("echo 'AMDGPU-COREDUMP-PAYLOAD' > /run/fake-devcoredump/devcd0/data")
+
+    machine.succeed("systemctl start gpu-coredump-capture@devcd0.service")
+
+    # The dump is stored compressed, with the kernel log context beside it.
+    dump = machine.succeed("ls /var/lib/gpu-coredumps/*.dump.gz").strip()
+    assert "devcd0" in dump, dump
+    payload = machine.succeed(f"zcat {dump}")
+    assert "AMDGPU-COREDUMP-PAYLOAD" in payload, payload
+    machine.succeed("ls /var/lib/gpu-coredumps/*.kmsg")
+
+    # A vanished node must not fail the unit; the kernel expires dumps on its
+    # own schedule and may win the race.
+    machine.succeed("rm /run/fake-devcoredump/devcd0/data")
+    machine.succeed("systemctl start gpu-coredump-capture@devcd0.service")
+
+    # Retention: with maxDumps = 2, a third capture evicts the oldest pair.
+    machine.succeed("echo payload > /run/fake-devcoredump/devcd0/data")
+    for _ in range(3):
+        # Timestamps have second resolution, so space the captures out to keep
+        # the filenames distinct.
+        machine.succeed("sleep 1; systemctl start gpu-coredump-capture@devcd0.service")
+
+    assert machine.succeed("ls -1 /var/lib/gpu-coredumps/*.dump.gz | wc -l").strip() == "2"
+    assert machine.succeed("ls -1 /var/lib/gpu-coredumps/*.kmsg | wc -l").strip() == "2"
+
+    # The udev rule that drives all of the above in production must be installed.
+    rules = machine.succeed("cat /etc/udev/rules.d/*.rules")
+    assert "SUBSYSTEM==\"devcoredump\"" in rules, rules
+    assert "gpu-coredump-capture@" in rules, rules
+  '';
+
+  # VM test only makes sense on x86_64; keep it off emulated aarch64 builders.
+  meta.platforms = ["x86_64-linux"];
+}

--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -40,9 +40,27 @@
       asus-desktop
       zfs
       failure-notify
+      gpu-coredump
     ]);
 
-  services.lyndenoAcme.enable = true;
+  services = {
+    lyndenoAcme.enable = true;
+
+    # The RX 6700 XT intermittently hangs the graphics ring and takes the
+    # session with it; the kernel deletes its coredump minutes later, so grab
+    # it on sight.
+    gpuCoredump.enable = true;
+
+    failureNotify = {
+      enable = true;
+      units = [
+        "borgbackup-job-borgbase"
+        "immich-stack"
+        "nix-gc"
+        "nixos-upgrade"
+      ];
+    };
+  };
 
   hostMeta = {
     description = "Main workstation and home server — programming, gaming, multimedia, and self-hosted services.";
@@ -52,16 +70,6 @@
       - LUKS-encrypted root, Secure Boot via lanzaboote
       - Services: Immich, Plex, Paperless-ngx, Firefly III, Vikunja, Home Assistant, Attic, Hydra, Nixarr, LubeLogger, Ollama
     '';
-  };
-
-  services.failureNotify = {
-    enable = true;
-    units = [
-      "borgbackup-job-borgbase"
-      "immich-stack"
-      "nix-gc"
-      "nixos-upgrade"
-    ];
   };
 
   age = {

--- a/modules/nixos/asus-desktop/default.nix
+++ b/modules/nixos/asus-desktop/default.nix
@@ -15,7 +15,7 @@
   };
 
   boot = {
-    kernelModules = ["kvm-amd" "jc42" "nct6775" "ddcci" "sg"];
+    kernelModules = ["kvm-amd" "jc42" "nct6775" "sg"];
     kernelParams = ["amdgpu.sg_display=0"];
     initrd = {
       availableKernelModules = ["nvme" "mpt3sas" "xhci_pci" "ahci" "usb_storage" "usbhid" "sd_mod"];

--- a/modules/nixos/gpu-coredump/README.md
+++ b/modules/nixos/gpu-coredump/README.md
@@ -37,9 +37,39 @@ context is lost. This context is innocent.` If the soft per-ring reset succeeded
 you would see a brief stutter and nothing more; the escalation to a full MODE1
 device reset is what loses VRAM and every GPU context on the system.
 
-The faulting process has differed each time (`python3.13`, then `alacritty`),
+The faulting process has differed each time — qutebrowser, then alacritty —
 which points at the userspace driver rather than any one application. Confirming
 that, and filing anything actionable upstream, needs the coredump.
+
+Note that qutebrowser appears in these logs as `python3.13`. Its wrapper execs
+the interpreter directly, so the kernel only ever sees the interpreter's name,
+and Mesa's submission thread inherits it as `python3.13:cs0`. Anything named
+`python3.13` in a GPU fault on this host is almost certainly qutebrowser; check
+`coredumpctl info <pid>` for the command line to be sure.
+
+That the two clients have so little in common is itself the useful signal.
+qutebrowser is Qt6 WebEngine running Chromium through ANGLE; alacritty is a
+small direct-OpenGL terminal. What they share is radeonsi underneath — and a
+machine running the same niri, alacritty and Mesa on Intel graphics (neo) has
+never reproduced this, which rules out the compositor and the applications and
+leaves the AMD-specific stack.
+
+### A hypothesis the dumps can test
+
+Three things are constant across both events: the faulting client is `TCP` (the
+texture cache), `RW` is `0x0` (a read), and the ring that actually times out
+belongs to niri rather than to the client that faulted.
+
+That fits a fault while *sampling a client buffer during compositing* better
+than it fits either client's own rendering — both applications hand dmabufs to
+niri to be textured onto the screen, and a modifier or mapping bug on that
+import path would produce this signature across otherwise unrelated clients.
+
+The simpler reading is that the client's own shader faults and niri's ring is
+collateral once the GPU is wedged. Fault attribution cannot separate the two,
+especially with `MORE_FAULTS: 0x1` indicating a storm. The coredump can: it
+names the shader. If that turns out to be a compositing or blit shader rather
+than anything belonging to the client, the import path is the place to look.
 
 ## The problem this module solves
 
@@ -97,10 +127,19 @@ grep -E 'Process|ring .* timeout|reset' /var/lib/gpu-coredumps/<timestamp>-devcd
 zcat /var/lib/gpu-coredumps/<timestamp>-devcd0.dump.gz | less
 ```
 
-The thing to watch across several captures is whether the faulting process keeps
-changing. Different applications hitting an identical fault signature is evidence
-the bug is in Mesa (26.1.5 at time of writing, on kernel 6.18.43) rather than in
-any particular application.
+Two things are worth watching across several captures. Whether the faulting
+process keeps changing — different applications hitting an identical fault
+signature is evidence the bug is in Mesa (26.1.5 at time of writing, on kernel
+6.18.43) rather than in any particular application. And which shader the dump
+names, which is what distinguishes the two readings described above: a client's
+own shader, or a compositing one.
+
+Also worth recording is whether ollama was running inference at the time. It
+uses ROCm with `rocmOverrideGfx = "10.3.0"` — the card is gfx1031, so compute
+kernels are built for a different chip, which is a plausible source of exactly
+this kind of out-of-bounds read. It did not correlate with the first two events
+(the nearest inference was hours earlier, with no model resident), but it is
+cheap to check and would be a strong lead if it ever lines up.
 
 ## Options
 

--- a/modules/nixos/gpu-coredump/README.md
+++ b/modules/nixos/gpu-coredump/README.md
@@ -134,12 +134,31 @@ signature is evidence the bug is in Mesa (26.1.5 at time of writing, on kernel
 names, which is what distinguishes the two readings described above: a client's
 own shader, or a compositing one.
 
-Also worth recording is whether ollama was running inference at the time. It
-uses ROCm with `rocmOverrideGfx = "10.3.0"` — the card is gfx1031, so compute
-kernels are built for a different chip, which is a plausible source of exactly
-this kind of out-of-bounds read. It did not correlate with the first two events
-(the nearest inference was hours earlier, with no model resident), but it is
-cheap to check and would be a strong lead if it ever lines up.
+Also worth recording is whether ollama was running inference at the time, and
+if so how much VRAM it held.
+
+Note that ollama does **not** use ROCm here despite `rocmOverrideGfx =
+"10.3.0"` being set in its module. It runs on Vulkan, so that override is
+inert:
+
+```
+llama_prepare_model_devices: using device Vulkan0 (AMD Radeon RX 6700 XT (RADV NAVI22))
+```
+
+That makes it more relevant to this bug rather than less. RADV is Mesa's AMD
+Vulkan driver, so ollama is a heavy client of the same AMD-specific userspace
+stack already under suspicion — and it is one of the things neo, which never
+reproduces this, does not run at all.
+
+VRAM pressure is the specific thing to look at. A loaded model takes roughly
+8.7 GB of the card's 12 GB, leaving under 2 GB for everything else, and buffer
+eviction under that kind of pressure is a plausible route to a texture read
+landing on an unmapped page.
+
+It did not correlate with the first two events: the nearest inference was
+3h17m and 7h37m earlier respectively. Be aware that ollama does not log model
+unloads at the default log level, so residency has to be inferred from the
+keep-alive rather than read directly.
 
 ## Options
 

--- a/modules/nixos/gpu-coredump/README.md
+++ b/modules/nixos/gpu-coredump/README.md
@@ -1,0 +1,149 @@
+# gpu-coredump
+
+Saves DRM device coredumps to persistent storage before the kernel deletes them.
+
+## Why this exists
+
+Morpheus' RX 6700 XT intermittently hangs its graphics ring and takes the whole
+graphical session with it — screens black for a second or two, then back at GDM
+with every application gone. As of August 2026 this happened roughly every one
+to two days of active use.
+
+The failure is always the same two-stage sequence. First, some client's shader
+reads unmapped memory:
+
+```
+amdgpu: [gfxhub] page fault (src_id:0 ring:24 vmid:5 pasid:522)
+amdgpu:  Process alacritty pid 2931230 thread alacritty:cs0
+amdgpu:   in page starting at address 0x0000800901823000 from client 0x1b (UTCL2)
+amdgpu:          Faulty UTCL2 client ID: TCP (0x8)
+amdgpu:          PERMISSION_FAULTS: 0x3
+```
+
+Roughly ten seconds later the graphics ring times out, and recovery escalates:
+
+```
+amdgpu: ring gfx_0.1.0 timeout, signaled seq=2372840, emitted seq=2372842
+amdgpu:  Process niri pid 947802 thread niri:cs0
+amdgpu: Starting gfx_0.1.0 ring reset
+amdgpu: Ring gfx_0.1.0 reset failed          <-- soft recovery fails
+amdgpu: GPU reset begin!. Source:  1
+amdgpu: MODE1 reset
+amdgpu: VRAM is lost due to GPU reset!
+```
+
+The compositor is a bystander — it dies with `The CS has cancelled because the
+context is lost. This context is innocent.` If the soft per-ring reset succeeded
+you would see a brief stutter and nothing more; the escalation to a full MODE1
+device reset is what loses VRAM and every GPU context on the system.
+
+The faulting process has differed each time (`python3.13`, then `alacritty`),
+which points at the userspace driver rather than any one application. Confirming
+that, and filing anything actionable upstream, needs the coredump.
+
+## The problem this module solves
+
+When amdgpu detects the hang it writes a coredump and says so:
+
+```
+amdgpu: [drm] AMDGPU device coredump file has been created
+amdgpu: [drm] Check your /sys/class/drm/card1/device/devcoredump/data
+```
+
+The kernel then deletes it about five minutes later (`DEVCD_TIMEOUT`). Since the
+session has just been destroyed, five minutes is spent logging back in and
+reopening windows — the dump is reliably gone before anyone thinks to look. It
+cannot be caught by hand.
+
+So a udev rule catches the node the instant it appears.
+
+## How it works
+
+```
+ACTION=="add", SUBSYSTEM=="devcoredump", TAG+="systemd", \
+  ENV{SYSTEMD_WANTS}+="gpu-coredump-capture@%k.service"
+```
+
+The rule hands off to a systemd unit rather than doing the copy in `RUN+=`.
+udev runs `RUN+=` synchronously against the event queue, and stalling that queue
+while reading tens of megabytes — at the exact moment the GPU is already wedged
+and devices are being torn down and re-probed — is a bad trade for the small
+amount of indirection saved.
+
+Each capture writes two files to `/var/lib/gpu-coredumps/`:
+
+| File | Contents |
+| --- | --- |
+| `<timestamp>-devcdN.dump.gz` | The coredump itself, gzipped |
+| `<timestamp>-devcdN.kmsg` | The last 300 lines of kernel log |
+
+The `.kmsg` sidecar is not an afterthought. The dump is written when the hang is
+detected, *before* the reset, so at capture time the kernel ring buffer still
+holds the page faults that led up to it — including the `Process <name>` lines
+identifying the guilty client. That context is what makes the dump interpretable,
+and it is the part that was lost on the August 16th event.
+
+Nothing is deleted from sysfs, so the kernel's own expiry is unaffected.
+
+## Reading a capture
+
+```bash
+ls -la /var/lib/gpu-coredumps/
+
+# Which process faulted, and what the driver did about it
+grep -E 'Process|ring .* timeout|reset' /var/lib/gpu-coredumps/<timestamp>-devcd0.kmsg
+
+# The dump itself: register state, ring contents, the faulting shader
+zcat /var/lib/gpu-coredumps/<timestamp>-devcd0.dump.gz | less
+```
+
+The thing to watch across several captures is whether the faulting process keeps
+changing. Different applications hitting an identical fault signature is evidence
+the bug is in Mesa (26.1.5 at time of writing, on kernel 6.18.43) rather than in
+any particular application.
+
+## Options
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `services.gpuCoredump.enable` | `false` | Install the rule and unit |
+| `services.gpuCoredump.outputDir` | `/var/lib/gpu-coredumps` | Where captures land |
+| `services.gpuCoredump.maxDumps` | `20` | Captures retained; older pairs pruned after each run |
+| `services.gpuCoredump.sourceDir` | `/sys/class/devcoredump` | Where devcoredump nodes appear |
+
+Retention is a real concern rather than tidiness: a GPU stuck in a reset loop
+would otherwise write dumps until the filesystem fills.
+
+`sourceDir` exists so the test can point at a fixture directory instead of real
+sysfs. It should not need changing on a live host.
+
+## Scope
+
+The udev rule matches the `devcoredump` subsystem as a whole, not amdgpu
+specifically — the failing driver is not exposed as a property on the devcd node
+in a form worth matching against. Any driver that produces a devcoredump will
+therefore be captured too (some wireless firmware does this). On these hosts
+amdgpu is the only producer in practice, and `maxDumps` bounds the cost either
+way.
+
+## Testing
+
+`checks/gpu-coredump.nix` covers everything downstream of the udev event: the
+capture service, the compressed dump, the `.kmsg` sidecar, retention pruning, the
+race where the kernel expires the node first, and that the rule is installed.
+
+A real devcoredump can only be produced by a driver hitting an actual hardware
+hang, which a VM cannot stage, so the test points `sourceDir` at a fixture
+directory. The udev rule firing against live hardware is consequently the one
+part not covered.
+
+```bash
+nix build .#checks.x86_64-linux.gpu-coredump
+```
+
+## Retiring this
+
+This module is diagnostic scaffolding for a specific open bug. Once the ring
+hangs are resolved — most likely by a Mesa or kernel version change — drop
+`services.gpuCoredump.enable` from the host, and remove the module if nothing
+else has come to depend on it.

--- a/modules/nixos/gpu-coredump/default.nix
+++ b/modules/nixos/gpu-coredump/default.nix
@@ -1,0 +1,89 @@
+# meta.description = "Saves DRM/amdgpu device coredumps before the kernel expires them"
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.gpuCoredump;
+
+  # The kernel drops a devcoredump into sysfs when a GPU hang is detected, then
+  # deletes it roughly five minutes later. That window is far too short to catch
+  # by hand, so a udev event kicks off this script the moment the node appears.
+  captureScript = pkgs.writeShellScript "gpu-coredump-capture" ''
+    set -euo pipefail
+    export PATH="${lib.makeBinPath [pkgs.coreutils pkgs.gzip pkgs.systemd]}:$PATH"
+
+    dev="$1"
+    src="${cfg.sourceDir}/$dev/data"
+    dest="${cfg.outputDir}"
+    base="$dest/$(date -u +%Y%m%dT%H%M%SZ)-$dev"
+
+    if [ ! -r "$src" ]; then
+      echo "no readable coredump at $src; it likely expired already" >&2
+      exit 0
+    fi
+
+    # Dumps run to tens of megabytes uncompressed and compress very well.
+    gzip -c "$src" > "$base.dump.gz"
+
+    # The dump is written when the hang is detected, before the reset, so the
+    # kernel ring buffer still holds the page faults that led up to it. Those
+    # are what identify the faulting process, so keep them alongside the dump.
+    journalctl -k -n 300 --no-pager > "$base.kmsg" 2>&1 || true
+
+    chmod 0640 "$base.dump.gz" "$base.kmsg" || true
+    echo "captured $(stat -c %s "$base.dump.gz") compressed bytes to $base.dump.gz"
+
+    # Keep the newest ${toString cfg.maxDumps}; a reset loop must not fill the disk.
+    ls -1t "$dest"/*.dump.gz 2>/dev/null | tail -n +$((${toString cfg.maxDumps} + 1)) | while read -r old; do
+      rm -f "$old" "''${old%.dump.gz}.kmsg"
+    done
+  '';
+in {
+  options.services.gpuCoredump = {
+    enable = lib.mkEnableOption "capture of DRM device coredumps to persistent storage";
+
+    outputDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/gpu-coredumps";
+      description = "Directory the captured dumps and their kernel log context are written to.";
+    };
+
+    maxDumps = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 20;
+      description = ''
+        Number of captures to retain. Older dumps are pruned after each capture
+        so that a repeated hang cannot exhaust the filesystem.
+      '';
+    };
+
+    sourceDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/sys/class/devcoredump";
+      description = ''
+        Where devcoredump nodes appear. Only worth changing in tests, which
+        point it at a fixture directory instead of real sysfs.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.rules = ["d ${cfg.outputDir} 0750 root root -"];
+
+    systemd.services."gpu-coredump-capture@" = {
+      description = "Capture DRM device coredump %i";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${captureScript} %i";
+      };
+    };
+
+    # Hand off to systemd rather than doing the copy in RUN+=, so a large dump
+    # cannot stall the udev event queue.
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="devcoredump", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gpu-coredump-capture@%k.service"
+    '';
+  };
+}


### PR DESCRIPTION
## Background

Morpheus' RX 6700 XT intermittently hangs its graphics ring and takes the whole graphical session with it — screens black for a second or two, then back at GDM with every application gone. Login records put this at roughly every one to two days of active use.

Every occurrence follows the same two stages. A client shader reads unmapped memory:

```
amdgpu: [gfxhub] page fault (src_id:0 ring:24 vmid:5 pasid:522)
amdgpu:  Process alacritty pid 2931230 thread alacritty:cs0
amdgpu:          Faulty UTCL2 client ID: TCP (0x8)
amdgpu:          PERMISSION_FAULTS: 0x3
```

~10s later the ring times out and recovery escalates:

```
amdgpu: ring gfx_0.1.0 timeout, signaled seq=2372840, emitted seq=2372842
amdgpu: Starting gfx_0.1.0 ring reset
amdgpu: Ring gfx_0.1.0 reset failed          <-- soft recovery fails
amdgpu: MODE1 reset
amdgpu: VRAM is lost due to GPU reset!
```

The compositor is a bystander (`This context is innocent.`). Had the soft per-ring reset succeeded there would only be a brief stutter; the escalation to a full MODE1 reset is what loses VRAM and every GPU context.

The faulting process has differed between events (`python3.13`, then `alacritty`), pointing at Mesa rather than any one application. Confirming that needs the coredump amdgpu writes on hang detection — but the kernel expires it after ~5 minutes, which is exactly the time spent logging back in and reopening windows. It cannot be caught by hand.

## Changes

- **New `gpu-coredump` module.** A udev rule on the `devcoredump` subsystem hands off to a systemd unit, rather than copying in `RUN+=` — reading tens of megabytes must not stall the udev event queue while devices are being torn down and re-probed. Each capture writes the gzipped dump plus the last 300 kernel lines to `/var/lib/gpu-coredumps/`. The `.kmsg` sidecar matters because the dump is written *before* the reset, so the ring buffer still holds the page faults naming the guilty client. Retention is capped (`maxDumps`, default 20) so a reset loop cannot fill the disk.
- **Module README** documenting the failure chain, how to read a capture, the scope caveat (the rule matches all `devcoredump` producers, not amdgpu specifically), and how to retire the module once the bug is resolved.
- **Drop `ddcci`** from `asus-desktop` `kernelModules`. Unused, and failing to load on every boot (`Failed to find module 'ddcci'`) since it isn't built for this kernel.
- **Collapse morpheus' three `services.*` assignments** into one block, which adding a third would otherwise have tripped statix on. Verified to build to an identical store path.
- Regenerated `README.md` and `.mergify.yml`.

## Testing

- `checks/gpu-coredump.nix` passes — covers the capture service, compressed dump, `.kmsg` sidecar, retention pruning, the race where the kernel expires the node first, and that the udev rule is installed. A real devcoredump needs an actual hardware hang, which a VM cannot stage, so the test points `sourceDir` at a fixture directory; the udev rule firing against live hardware is the one part not covered.
- `nixosConfigurations.morpheus` builds; udev rule and unit confirmed present in the output and armed on the running host.
- `readme` and `mergify` drift checks pass; deadnix, statix and treefmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwSixKVqbu4tVY9w19KhJS