### PR TITLE
feat: Add modprobed-db module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ pubKeys.nix                       # SSH/Age public keys for hosts and users
 | `laptop` | Laptop power management: suspend-then-hibernate, iwd, geolocated timezone |
 | `localProxy` | nginx reverse proxy exposing local services on subdomains |
 | `lubelogger` | LubeLogger vehicle maintenance tracker |
+| `modprobed-db` | Records every kernel module ever loaded, for `make localmodconfig` |
 | `msmtp` | System mail relay via msmtp (Fastmail) |
 | `niri` | Niri scrolling Wayland compositor |
 | `nixarr` | Media automation stack (Sonarr/Radarr/Prowlarr/Transmission) behind a VPN |

--- a/hosts/morpheus/configuration.nix
+++ b/hosts/morpheus/configuration.nix
@@ -20,6 +20,7 @@
       niri
       secureboot
       hydraCache
+      modprobed-db
       attic-watch
       acme
       localProxy
@@ -45,6 +46,10 @@
 
   services = {
     lyndenoAcme.enable = true;
+
+    # Accumulating toward a localmodconfig-derived kernel; this host's module
+    # set only shows up in full once every disk, VM, and service has run.
+    modprobedDb.enable = true;
 
     # The RX 6700 XT intermittently hangs the graphics ring and takes the
     # session with it; the kernel deletes its coredump minutes later, so grab

--- a/hosts/neo/configuration.nix
+++ b/hosts/neo/configuration.nix
@@ -16,6 +16,7 @@
     secureboot
     laptop
     hydraCache
+    modprobed-db
     ./borgbackup/borgbase.nix
     ./disko.nix
   ];
@@ -24,6 +25,10 @@
   system.stateVersion = "21.11";
 
   nixpkgs.hostPlatform = "x86_64-linux";
+
+  # Accumulating toward a localmodconfig-derived kernel; the laptop's real
+  # module set only appears once every dock, peripheral, and suspend has run.
+  services.modprobedDb.enable = true;
 
   hostMeta = {
     description = "Development laptop; occasional gaming.";

--- a/modules/nixos/modprobed-db/default.nix
+++ b/modules/nixos/modprobed-db/default.nix
@@ -1,0 +1,198 @@
+# meta.description = "Records every kernel module ever loaded, for `make localmodconfig`"
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.modprobedDb;
+
+  dbFile = "${cfg.stateDir}/modprobed.db";
+
+  # The upstream script has no flags: everything comes from a config file it
+  # locates via $XDG_CONFIG_HOME. Point that at a store directory holding a
+  # generated config so the whole thing stays declarative and read-only.
+  configDir = pkgs.writeTextDir "modprobed-db.conf" ''
+    DBPATH="${cfg.stateDir}"
+    COLORS=dark
+    IGNORE=(${lib.concatStringsSep " " cfg.ignoredModules})
+  '';
+
+  # An empty database is the signature of the script's tools being unavailable:
+  # it exits 0 and logs "New database created", so the unit looks healthy while
+  # recording nothing. Left unchecked that is only noticed weeks later, when the
+  # db is supposed to drive a kernel config. Fail loudly instead.
+  assertNonEmpty = pkgs.writeShellScript "modprobed-db-assert-nonempty" ''
+    if [ ! -s "${dbFile}" ]; then
+      echo "modprobed-db produced an empty database at ${dbFile}" >&2
+      echo "this usually means a helper binary is missing from the unit PATH" >&2
+      exit 1
+    fi
+  '';
+
+  # Without this the CLI on $PATH would fall back to a per-user config and
+  # report on a database in ~/.config, not the one the timer maintains.
+  modprobed-db = pkgs.symlinkJoin {
+    name = "modprobed-db-system";
+    paths = [pkgs.modprobed-db];
+    nativeBuildInputs = [pkgs.makeWrapper];
+    postBuild = ''
+      wrapProgram $out/bin/modprobed-db --set XDG_CONFIG_HOME ${configDir}
+    '';
+  };
+in {
+  options.services.modprobedDb = {
+    enable = lib.mkEnableOption ''
+      periodic recording of loaded kernel modules into a cumulative database.
+
+      `make localmodconfig` only sees the modules loaded at the instant it
+      runs, which misses anything hotplugged, mounted, or started at some
+      other time. This accumulates the union over weeks so the resulting
+      config covers hardware and workloads that were not active during the
+      build
+    '';
+
+    interval = lib.mkOption {
+      type = lib.types.str;
+      default = "15min";
+      example = "6h";
+      description = ''
+        `OnUnitActiveSec=` for the timer. A module that is loaded and unloaded
+        entirely within one interval is never recorded, so this is
+        deliberately shorter than upstream's 6h default; the scan is only a
+        read of /proc/modules and costs effectively nothing.
+      '';
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/modprobed-db";
+      description = ''
+        Directory holding `modprobed.db`. The database is world-readable so it
+        can be fed to a kernel build as an unprivileged user:
+
+        `make LSMOD=${dbFile} localmodconfig`
+      '';
+    };
+
+    dbPath = lib.mkOption {
+      type = lib.types.str;
+      readOnly = true;
+      default = dbFile;
+      description = ''
+        Resolved path to the database, for referring to from a kernel build
+        without restating the layout.
+      '';
+    };
+
+    ignoredModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        # Out-of-tree modules have no Kconfig symbol in the kernel tree, so
+        # localmodconfig cannot act on them. Recording them is harmless but
+        # makes the db misleading when read by hand.
+        "nvidia"
+        "nvidia_drm"
+        "nvidia_modeset"
+        "nvidia_uvm"
+        "v4l2loopback"
+        "vboxdrv"
+        "vboxnetadp"
+        "vboxnetflt"
+        "vboxpci"
+        # ZFS and its SPL dependencies, built out-of-tree against the kernel.
+        "icp"
+        "spl"
+        "zavl"
+        "zcommon"
+        "zfs"
+        "zlua"
+        "znvpair"
+        "zunicode"
+        "zzstd"
+      ];
+      description = ''
+        Module names excluded from the database. Matched as anchored regex
+        alternatives against each name in /proc/modules.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [modprobed-db];
+
+    systemd.services.modprobed-db = {
+      description = "Record newly loaded kernel modules into the modprobed database";
+      documentation = ["man:modprobed-db(8)"];
+
+      # The script derives its home directory from $USER (falling back to
+      # logname(1), which fails without a tty) and refuses to run if it cannot.
+      # Nothing under it is actually used once XDG_CONFIG_HOME is set, but the
+      # lookup still has to succeed, so pin it rather than depend on whether
+      # systemd exported $USER for a root unit.
+      environment = {
+        USER = "root";
+        XDG_CONFIG_HOME = configDir;
+      };
+
+      # The script has no `set -e`, so a missing tool does not stop it: it just
+      # produces empty output and writes an empty database. Do not rely on
+      # systemd's default PATH — list everything the script actually calls.
+      path = [
+        pkgs.coreutils
+        pkgs.gawk
+        pkgs.getent
+        pkgs.gnugrep
+        pkgs.gnused
+        pkgs.kmod
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        # `storesilent` runs the db-creating check first, so the initial run
+        # bootstraps the file itself; no seeding step is needed.
+        ExecStart = "${modprobed-db}/bin/modprobed-db storesilent";
+        ExecStartPost = assertNonEmpty;
+
+        StateDirectory = "modprobed-db";
+        StateDirectoryMode = "0755";
+
+        # Scratch files are hardcoded to /tmp/.inmem and /tmp/.potential_new_db,
+        # which is both a collision and a symlink-attack surface on a shared /tmp.
+        PrivateTmp = true;
+
+        # Reads /proc/modules and writes StateDirectory; needs nothing else.
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateNetwork = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = ["AF_UNIX"];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = ["@system-service" "~@privileged" "~@resources"];
+      };
+    };
+
+    systemd.timers.modprobed-db = {
+      description = "Periodically scan for newly loaded kernel modules";
+      wantedBy = ["timers.target"];
+      timerConfig = {
+        # Catch the early-boot and initrd modules once userspace has settled,
+        # then sample on the interval for anything hotplugged later.
+        OnBootSec = "2min";
+        OnUnitActiveSec = cfg.interval;
+        Persistent = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Records the union of every kernel module ever loaded into `/var/lib/modprobed-db/modprobed.db`, so a future kernel build can be driven by `make LSMOD=... localmodconfig` without dropping drivers that happened to be idle at build time. Enabled on **morpheus** and **neo**.

Groundwork for building a minimal kernel — the current dynamic-derivations implementation blows up kernel build time, and a smaller module set is the lever.

## Why a system unit

Upstream only ships a *user* timer writing to `~/.config`, which misses modules loaded during initrd and by system services. This runs as a root system unit instead, writing to a `StateDirectory`. The database is mode 0644 so it can be fed to a build unprivileged.

## Working around the script

- **No CLI flags** — every setting comes from a config file located via `$XDG_CONFIG_HOME`. The module generates that config into the store and points the unit at it, keeping things declarative.
- **The CLI on `$PATH` is wrapped** to use the same config, so `modprobed-db list` reports on the system database rather than silently falling back to a separate one in `~/.config`.
- **`$USER` is pinned to `root`** — the script derives its home directory from it, falling back to `logname(1)`, which fails without a tty and aborts the script.
- **`PrivateTmp=true`** — scratch files are hardcoded to `/tmp/.inmem` and `/tmp/.potential_new_db`.

## The empty-database failure mode

The script has no `set -e`. A binary missing from the unit PATH leaves it writing an **empty** database while still exiting 0 and logging `New database created` — this happened on neo with `awk`, and is the kind of thing you'd only notice weeks later when the db is supposed to drive a kernel config.

Two mitigations: the unit lists every binary the script calls rather than relying on systemd's default PATH, and an `ExecStartPost` check fails the unit if the database ends up empty.

## Defaults

- `interval = "15min"` (upstream is 6h). A module loaded and unloaded within one interval is never recorded, and the scan is just a read of `/proc/modules`.
- `ignoredModules` excludes out-of-tree modules — nvidia, VirtualBox, and the full ZFS/SPL set for morpheus. These have no Kconfig symbol so `localmodconfig` can't act on them.
- `dbPath` is exposed read-only for a future kernel derivation to reference.

## Testing

- Ran the script under the unit's exact PATH: 233 modules recorded, idempotent on re-run, exit 0.
- Verified the `ExecStartPost` guard: exit 0 on a populated db, exit 1 on an empty one.
- Confirmed the wrapper's `XDG_CONFIG_HOME` override takes effect.
- Both host toplevels evaluate; `checks.x86_64-linux.readme` passes with the regenerated `README.md`.

No `.mergify.yml` change needed — nothing was added to `packages/` or `checks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2BHFGptXLb1KEHeHm3zYE