### PR TITLE
Waybar: exit node tooltip + phone battery widget

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,6 +36,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-fan-average
+  - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-phone-battery
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:aarch64-linux.pkgs-wob-brightness
@@ -83,6 +84,7 @@ pull_request_rules:
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-email
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-fan-average
+  - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-phone-battery
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wb-ts
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-webcam-picker
   - check-success*=ci/hydra:nix-config:*:x86_64-linux.pkgs-wob-brightness

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ pubKeys.nix                       # SSH/Age public keys for hosts and users
 | `wb-cast` | Waybar module showing the current niri screencast target |
 | `wb-email` | Waybar module showing the unread email count |
 | `wb-fan` | Waybar module showing fan speed |
+| `wb-phone-battery` | Waybar module showing phone battery status via BatteryInfoServer |
 | `wb-ts` | Waybar module showing the active Tailscale exit node |
 | `webcam-picker` | Picks a webcam via fuzzel and launches a viewer |
 | `wob-brightness` | Adjusts screen brightness with a wob overlay bar |

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -74,7 +74,6 @@
           modules-left = ["niri/workspaces" (lib.mkIf (hostName != "neo") "cava")];
           modules-center = ["mpris" "custom/cast"];
           modules-right = [
-            (lib.mkIf (hostName == "neo" || hostName == "morpheus") "custom/ts")
             (lib.mkIf config.programs.aerc.enable "custom/email")
             "custom/update"
             "systemd-failed-units"
@@ -84,6 +83,7 @@
             "cpu"
             "memory"
             "network"
+            (lib.mkIf (hostName == "neo" || hostName == "morpheus") "custom/ts")
             "battery"
             "pulseaudio"
             "group/group-clock"

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -54,6 +54,9 @@
           #custom-cast {
             padding: 0 5px;
           }
+          #custom-phone-battery {
+            padding: 0 5px;
+          }
           #privacy {
             padding: 0 5px;
             background-color: @base08;
@@ -92,6 +95,7 @@
             "network"
             (lib.mkIf tailscale.enable "custom/ts")
             "battery"
+            (lib.mkIf tailscale.enable "custom/phone-battery")
             "pulseaudio"
             "group/group-clock"
           ];
@@ -160,6 +164,15 @@
             interval = 3;
             return-type = "json";
             format = "󰲐 {}";
+            tooltip = true;
+            hide-empty-text = true;
+          };
+
+          "custom/phone-battery" = lib.mkIf tailscale.enable {
+            exec = lib.getExe pkgs.wb-phone-battery;
+            interval = 60;
+            return-type = "json";
+            format = "{}";
             tooltip = true;
             hide-empty-text = true;
           };

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -77,6 +77,12 @@
           #battery.critical:not(.charging) {
             color: @base08;
           }
+          #custom-phone-battery.warning:not(.charging) {
+            color: @base0A;
+          }
+          #custom-phone-battery.critical:not(.charging) {
+            color: @base08;
+          }
         '';
       settings = {
         mainBar = {

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -50,6 +50,9 @@
           #custom-ts {
             padding: 0 5px;
           }
+          #custom-cast {
+            padding: 0 5px;
+          }
           #privacy {
             padding: 0 5px;
             background-color: @base08;
@@ -59,6 +62,9 @@
             padding: 0 5px;
           }
           #power-profiles-daemon {
+            padding: 0 5px;
+          }
+          #mpris {
             padding: 0 5px;
           }
           #battery.warning:not(.charging) {

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -8,6 +8,7 @@
   programs = {
     waybar = let
       inherit (osConfig.networking) hostName;
+      inherit (osConfig.services) tailscale;
 
       sensitivity =
         if hostName == "neo"
@@ -89,7 +90,7 @@
             "cpu"
             "memory"
             "network"
-            (lib.mkIf (hostName == "neo" || hostName == "morpheus") "custom/ts")
+            (lib.mkIf tailscale.enable "custom/ts")
             "battery"
             "pulseaudio"
             "group/group-clock"

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -137,7 +137,9 @@
           "custom/ts" = lib.mkIf (hostName == "neo" || hostName == "morpheus") {
             exec = lib.getExe pkgs.wb-ts;
             interval = 3;
+            return-type = "json";
             format = "󰲐 {}";
+            tooltip = true;
             hide-empty-text = true;
           };
 

--- a/modules/home/wlroots/waybar.nix
+++ b/modules/home/wlroots/waybar.nix
@@ -73,7 +73,21 @@
           height = 36;
           modules-left = ["niri/workspaces" (lib.mkIf (hostName != "neo") "cava")];
           modules-center = ["mpris" "custom/cast"];
-          modules-right = [(lib.mkIf (hostName == "neo" || hostName == "morpheus") "custom/ts") (lib.mkIf config.programs.aerc.enable "custom/email") "custom/update" "systemd-failed-units" "privacy" "custom/fan" "disk#root" "cpu" "memory" "network" "battery" "pulseaudio" "group/group-clock"];
+          modules-right = [
+            (lib.mkIf (hostName == "neo" || hostName == "morpheus") "custom/ts")
+            (lib.mkIf config.programs.aerc.enable "custom/email")
+            "custom/update"
+            "systemd-failed-units"
+            "privacy"
+            "custom/fan"
+            "disk#root"
+            "cpu"
+            "memory"
+            "network"
+            "battery"
+            "pulseaudio"
+            "group/group-clock"
+          ];
           "disk#root" = {
             interval = 30;
             format = "";

--- a/packages/wb-phone-battery.nix
+++ b/packages/wb-phone-battery.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  pname,
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.writeShellApplication {
+    name = pname;
+
+    runtimeInputs = with pkgs; [
+      curl
+      jq
+    ];
+
+    # Poll the BatteryInfoServer app (https://github.com/mfaizanse/BatteryInfoServer)
+    # running on the phone's Tailscale MagicDNS name. Prints an empty text field
+    # (hidden via hide-empty-text) when the phone is unreachable.
+    text = ''
+      response=$(curl -sS -m 5 --fail "http://cypher:9091/battery" 2>/dev/null || true)
+
+      if [ -z "$response" ]; then
+        echo '{"text":""}'
+      else
+        echo "$response" | jq -c '
+          .status as $s | .device as $d | .environment as $e
+          | ([$s.level / 10 | floor, 9] | min) as $idx
+          | (if $s.is_charging then "󰚥" else ["󰂎","󰁺","󰁻","󰁼","󰁽","󰁾","󰂀","󰂁","󰂂","󰁹"][$idx] end) as $icon
+          | {
+              text: ($icon + " " + ($s.level | tostring) + "%"),
+              tooltip: (
+                $d.model
+                + "\nBattery: " + ($s.level | tostring) + "% (" + $s.health + ")"
+                + "\nTemp: " + $s.temp
+                + "\nPower: " + $s.power_source
+                + "\nNetwork: " + $e.data_connection
+              )
+            }
+        '
+      fi
+    '';
+
+    meta.description = "Waybar module showing phone battery status via BatteryInfoServer";
+    meta.platforms = lib.platforms.linux;
+  }

--- a/packages/wb-phone-battery.nix
+++ b/packages/wb-phone-battery.nix
@@ -23,8 +23,9 @@ in
       else
         echo "$response" | jq -c '
           .status as $s | .device as $d | .environment as $e
-          | ([$s.level / 10 | floor, 9] | min) as $idx
-          | (if $s.is_charging then "󰚥" else ["󰂎","󰁺","󰁻","󰁼","󰁽","󰁾","󰂀","󰂁","󰂂","󰁹"][$idx] end) as $icon
+          | ([$s.level / 10 | floor, 10] | min) as $idx
+          | ["󰠒","󰠈","󰠉","󰠊","󰠋","󰠌","󰠍","󰠎","󰠏","󰠐","󰠇"][$idx] as $level_icon
+          | (if $s.is_charging then "󰠇" elif $s.level <= 15 then "󰠑" else $level_icon end) as $icon
           | {
               text: ($icon + " " + ($s.level | tostring) + "%"),
               tooltip: (
@@ -33,7 +34,11 @@ in
                 + "\nTemp: " + $s.temp
                 + "\nPower: " + $s.power_source
                 + "\nNetwork: " + $e.data_connection
-              )
+              ),
+              class: [
+                (if $s.level <= 15 then "critical" elif $s.level <= 30 then "warning" else empty end),
+                (if $s.is_charging then "charging" else empty end)
+              ]
             }
         '
       fi

--- a/packages/wb-ts.nix
+++ b/packages/wb-ts.nix
@@ -13,11 +13,24 @@ in
       jq
     ];
 
-    # Print the hostname of the active Tailscale exit node (empty if none).
+    # Print the active Tailscale exit node's hostname as waybar text, with a
+    # tooltip listing every available exit node's hostname, IP, and selection.
     text = ''
-      tailscale status --peers --json \
-        | jq '.ExitNodeStatus.ID as $node_id | .Peer[] | select(.ID==$node_id) | .HostName' \
-        | tr -d '"'
+      tailscale status --peers --json | jq -c '
+        [.Peer[] | select(.ExitNodeOption == true)] as $exit_nodes
+        | (($exit_nodes[] | select(.ExitNode) | .HostName) // "") as $active
+        | {
+            text: $active,
+            tooltip: (
+              if ($exit_nodes | length) == 0
+              then "No exit nodes available"
+              else $exit_nodes
+                | map(.HostName + " (" + (.TailscaleIPs[0] // "?") + ")" + (if .ExitNode then " — selected" else "" end))
+                | join("\n")
+              end
+            )
+          }
+      '
     '';
 
     meta.description = "Waybar module showing the active Tailscale exit node";

--- a/packages/wb-ts.nix
+++ b/packages/wb-ts.nix
@@ -19,13 +19,17 @@ in
       tailscale status --peers --json | jq -c '
         [.Peer[] | select(.ExitNodeOption == true)] as $exit_nodes
         | (($exit_nodes[] | select(.ExitNode) | .HostName) // "") as $active
+        | ($exit_nodes | map(.HostName | length) | max // 0) as $width
         | {
             text: $active,
             tooltip: (
               if ($exit_nodes | length) == 0
               then "No exit nodes available"
               else $exit_nodes
-                | map(.HostName + " (" + (.TailscaleIPs[0] // "?") + ")" + (if .ExitNode then " — selected" else "" end))
+                | map(
+                    (.HostName + (" " * ($width - (.HostName | length))) + " (" + (.TailscaleIPs[0] // "?") + ")") as $line
+                    | if .ExitNode then "<b><i>" + $line + "</i></b>" else $line end
+                  )
                 | join("\n")
               end
             )


### PR DESCRIPTION
## Summary
- Tailscale exit-node widget (`wb-ts`) gains a JSON tooltip listing every available exit node with IP and selection state, active node highlighted in bold/italic Pango markup with aligned hostnames.
- New phone battery widget (`wb-phone-battery`) polling BatteryInfoServer over Tailscale, placed next to the desktop battery module, using the `nf-md-battery_charging_wireless_*` icon family and the same warning/critical thresholds (30/15) as the built-in battery module. Hides cleanly when the phone is unreachable.
- Misc waybar cleanup: gate the tailscale module on `services.tailscale.enable` instead of hostname, reposition it next to `network`, formatting/padding fixes.
- Regenerated `README.md` and `.mergify.yml` for the new package.

## Test plan
- [x] `nix build .#wb-ts` / `.#wb-phone-battery` build cleanly (shellcheck via `writeShellApplication`)
- [x] Both scripts run against live Tailscale/phone state and produce expected JSON
- [x] Simulated unreachable phone confirmed graceful `{"text":""}` fallback
- [x] `nix build .#checks.x86_64-linux.readme` and `.#checks.x86_64-linux.mergify` pass
- [ ] Visual check in a running waybar session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fse4iZdrDKPxSQWSzqZ2A