### PR TITLE
mako: add background blur via ext-background-effect-v1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,13 @@
 
   outputs = inputs: let
     localOverlay = final: _prev: bp.mkPackagesFor final;
+    # Background blur for notifications via ext-background-effect-v1, backported from
+    # https://github.com/tpmajer/mako/compare/master...tpmajer:mako:flake
+    makoOverlay = _final: prev: {
+      mako = prev.mako.overrideAttrs (old: {
+        patches = (old.patches or []) ++ [./packages/mako-background-blur.patch];
+      });
+    };
     overlays = with inputs; [
       ironfetch.overlays.default
       apple-fonts.overlays.default
@@ -10,6 +17,7 @@
       agenix.overlays.default
       vim-niri-nav.overlays.default
       localOverlay
+      makoOverlay
       llm-agents.overlays.shared-nixpkgs
     ];
     bp = inputs.blueprint {

--- a/packages/mako-background-blur.patch
+++ b/packages/mako-background-blur.patch
@@ -1,0 +1,330 @@
+diff --git a/include/mako.h b/include/mako.h
+index dc2c372a..cd9634d5 100644
+--- a/include/mako.h
++++ b/include/mako.h
+@@ -14,10 +14,12 @@
+ 
+ #include "config.h"
+ #include "event-loop.h"
++#include "notification.h"
+ #include "pool-buffer.h"
+ #include "cursor-shape-v1-client-protocol.h"
+ #include "wlr-layer-shell-unstable-v1-client-protocol.h"
+ #include "xdg-activation-v1-client-protocol.h"
++#include "ext-background-effect-v1-client-protocol.h"
+ 
+ struct mako_state;
+ 
+@@ -29,6 +31,7 @@ struct mako_surface {
+ 	struct wl_surface *surface;
+ 	struct mako_output *surface_output;
+ 	struct zwlr_layer_surface_v1 *layer_surface;
++	struct ext_background_effect_surface_v1 *background_effect;
+ 	struct mako_output *layer_surface_output;
+ 	struct wl_callback *frame_callback;
+ 	bool configured;
+@@ -42,6 +45,10 @@ struct mako_surface {
+ 	int32_t width, height;
+ 	struct pool_buffer buffers[2];
+ 	struct pool_buffer *current_buffer;
++
++	bool has_hidden_hotspot;
++	struct mako_hotspot hidden_hotspot;
++	struct mako_directional hidden_border_radius;
+ };
+ 
+ struct mako_state {
+@@ -58,6 +65,8 @@ struct mako_state {
+ 	struct zwlr_layer_shell_v1 *layer_shell;
+ 	struct xdg_activation_v1 *xdg_activation;
+ 	struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
++	struct ext_background_effect_manager_v1 *background_effect_manager;
++	bool blur_supported;
+ 	struct wl_list outputs; // mako_output::link
+ 	struct wl_list seats; // mako_seat::link
+ 
+diff --git a/protocol/ext-background-effect-v1.xml b/protocol/ext-background-effect-v1.xml
+new file mode 100644
+index 00000000..88aab234
+--- /dev/null
++++ b/protocol/ext-background-effect-v1.xml
+@@ -0,0 +1,82 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<protocol name="ext_background_effect_v1">
++  <copyright>
++    Copyright (C) 2015 Martin Gräßlin
++    Copyright (C) 2015 Marco Martin
++    Copyright (C) 2020 Vlad Zahorodnii
++    Copyright (C) 2024 Xaver Hugl
++
++    Permission is hereby granted, free of charge, to any person obtaining a
++    copy of this software and associated documentation files (the "Software"),
++    to deal in the Software without restriction, including without limitation
++    the rights to use, copy, modify, merge, publish, distribute, sublicense,
++    and/or sell copies of the Software, and to permit persons to whom the
++    Software is furnished to do so, subject to the following conditions:
++
++    The above copyright notice and this permission notice (including the next
++    paragraph) shall be included in all copies or substantial portions of the
++    Software.
++
++    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++    DEALINGS IN THE SOFTWARE.
++  </copyright>
++
++  <interface name="ext_background_effect_manager_v1" version="1">
++    <description summary="background effect factory">
++      This protocol provides a way to improve visuals of translucent surfaces
++      by applying effects like blur to the background behind them.
++    </description>
++
++    <request name="destroy" type="destructor">
++      <description summary="destroy the background effect manager"/>
++    </request>
++
++    <enum name="error">
++      <entry name="background_effect_exists" value="0"
++             summary="the surface already has a background effect object"/>
++    </enum>
++
++    <enum name="capability" bitfield="true">
++      <entry name="blur" value="1"
++             summary="the compositor supports applying blur"/>
++    </enum>
++
++    <event name="capabilities">
++      <description summary="capabilities of the compositor"/>
++      <arg name="flags" type="uint" enum="capability"/>
++    </event>
++
++    <request name="get_background_effect">
++      <description summary="get a background effects object"/>
++      <arg name="id" type="new_id" interface="ext_background_effect_surface_v1"/>
++      <arg name="surface" type="object" interface="wl_surface"/>
++    </request>
++  </interface>
++
++  <interface name="ext_background_effect_surface_v1" version="1">
++    <description summary="background effects for a surface"/>
++
++    <request name="destroy" type="destructor">
++      <description summary="release the blur object"/>
++    </request>
++
++    <enum name="error">
++      <entry name="surface_destroyed" value="0"
++             summary="the associated surface has been destroyed"/>
++    </enum>
++
++    <request name="set_blur_region">
++      <description summary="set blur region">
++        Specifies the surface-local region behind which the compositor should
++        apply blur. Double-buffered: applied on the next wl_surface.commit.
++        NULL removes the effect.
++      </description>
++      <arg name="region" type="object" interface="wl_region" allow-null="true"/>
++    </request>
++  </interface>
++</protocol>
+diff --git a/protocol/meson.build b/protocol/meson.build
+index 0fa3f533..fa6ac7e7 100644
+--- a/protocol/meson.build
++++ b/protocol/meson.build
+@@ -22,6 +22,7 @@ protocols = [
+ 	wl_protocol_dir / 'staging/xdg-activation/xdg-activation-v1.xml',
+ 	wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
+ 	'wlr-layer-shell-unstable-v1.xml',
++	'ext-background-effect-v1.xml',
+ ]
+ 
+ protocols_src = []
+diff --git a/render.c b/render.c
+index 8cb20743..ddd015f6 100644
+--- a/render.c
++++ b/render.c
+@@ -343,6 +343,7 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
+ 	cairo_t *cairo = buffer->cairo;
+ 
+ 	*rendered_width = *rendered_height = 0;
++	surface->has_hidden_hotspot = false;
+ 
+ 	if (wl_list_empty(&state->notifications)) {
+ 		return;
+@@ -470,9 +471,14 @@ void render(struct mako_surface *surface, struct pool_buffer *buffer, int scale,
+ 			format_text(style->format, text, format_hidden_text, &data);
+ 
+ 			int hidden_height = render_notification(
+-				cairo, state, surface, style, text, NULL, total_height, scale, NULL, 0);
++				cairo, state, surface, style, text, NULL, total_height, scale,
++				&hidden_notif->hotspot, 0);
+ 			free(text);
+ 
++			surface->hidden_hotspot = hidden_notif->hotspot;
++			surface->hidden_border_radius = style->border_radius;
++			surface->has_hidden_hotspot = true;
++
+ 			total_height += hidden_height;
+ 			pending_bottom_margin = style->margin.bottom;
+ 		}
+diff --git a/surface.c b/surface.c
+index 96acaad9..521db904 100644
+--- a/surface.c
++++ b/surface.c
+@@ -8,6 +8,9 @@ void destroy_surface(struct mako_surface *surface) {
+ 	if (surface->layer_surface != NULL) {
+ 		zwlr_layer_surface_v1_destroy(surface->layer_surface);
+ 	}
++	if (surface->background_effect != NULL) {
++		ext_background_effect_surface_v1_destroy(surface->background_effect);
++	}
+ 	if (surface->surface != NULL) {
+ 		wl_surface_destroy(surface->surface);
+ 	}
+diff --git a/wayland.c b/wayland.c
+index 6dd91856..753f891d 100644
+--- a/wayland.c
++++ b/wayland.c
+@@ -411,6 +411,17 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
+ 	.closed = layer_surface_handle_closed,
+ };
+ 
++static void background_effect_manager_handle_capabilities(void *data,
++		struct ext_background_effect_manager_v1 *manager, uint32_t flags) {
++	struct mako_state *state = data;
++	state->blur_supported =
++		(flags & EXT_BACKGROUND_EFFECT_MANAGER_V1_CAPABILITY_BLUR) != 0;
++}
++
++static const struct ext_background_effect_manager_v1_listener
++		background_effect_manager_listener = {
++	.capabilities = background_effect_manager_handle_capabilities,
++};
+ 
+ static void handle_global(void *data, struct wl_registry *registry,
+ 		uint32_t name, const char *interface, uint32_t version) {
+@@ -439,6 +450,12 @@ static void handle_global(void *data, struct wl_registry *registry,
+ 	} else if (strcmp(interface, wp_cursor_shape_manager_v1_interface.name) == 0) {
+ 		state->cursor_shape_manager = wl_registry_bind(registry, name,
+ 			&wp_cursor_shape_manager_v1_interface, 1);
++	} else if (strcmp(interface, ext_background_effect_manager_v1_interface.name) == 0) {
++		state->background_effect_manager = wl_registry_bind(registry, name,
++			&ext_background_effect_manager_v1_interface, 1);
++		ext_background_effect_manager_v1_add_listener(
++			state->background_effect_manager,
++			&background_effect_manager_listener, state);
+ 	}
+ }
+ 
+@@ -539,6 +556,9 @@ void finish_wayland(struct mako_state *state) {
+ 	if (state->cursor_shape_manager != NULL) {
+ 		wp_cursor_shape_manager_v1_destroy(state->cursor_shape_manager);
+ 	}
++	if (state->background_effect_manager != NULL) {
++		ext_background_effect_manager_v1_destroy(state->background_effect_manager);
++	}
+ 
+ 	if (state->cursor.theme != NULL) {
+ 		wl_cursor_theme_destroy(state->cursor.theme);
+@@ -568,6 +588,46 @@ static struct wl_region *get_input_region(struct mako_surface *surface) {
+ 	return region;
+ }
+ 
++static void add_hotspot_blur_rect(struct wl_region *region,
++		struct mako_hotspot *hs, struct mako_directional *br) {
++	int32_t r = br->top;
++	if (br->right > r) r = br->right;
++	if (br->bottom > r) r = br->bottom;
++	if (br->left > r) r = br->left;
++
++	if (r == 0) {
++		wl_region_add(region, hs->x, hs->y, hs->width, hs->height);
++	} else {
++		wl_region_add(region, hs->x + r, hs->y,
++			hs->width - 2 * r, hs->height);
++		wl_region_add(region, hs->x, hs->y + r,
++			r, hs->height - 2 * r);
++		wl_region_add(region, hs->x + hs->width - r, hs->y + r,
++			r, hs->height - 2 * r);
++	}
++}
++
++static struct wl_region *get_blur_region(struct mako_surface *surface) {
++	struct wl_region *region =
++		wl_compositor_create_region(surface->state->compositor);
++
++	struct mako_notification *notif;
++	wl_list_for_each(notif, &surface->state->notifications, link) {
++		if (notif->surface != surface) {
++			continue;
++		}
++		add_hotspot_blur_rect(region, &notif->hotspot,
++			&notif->style.border_radius);
++	}
++
++	if (surface->has_hidden_hotspot) {
++		add_hotspot_blur_rect(region, &surface->hidden_hotspot,
++			&surface->hidden_border_radius);
++	}
++
++	return region;
++}
++
+ static struct mako_output *get_configured_output(struct mako_surface *surface) {
+ 	const char *output_name = surface->configured_output;
+ 	if (strcmp(output_name, "") == 0) {
+@@ -623,6 +683,10 @@ static void send_frame(struct mako_surface *surface) {
+ 			wl_callback_destroy(surface->frame_callback);
+ 			surface->frame_callback = NULL;
+ 		}
++		if (surface->background_effect != NULL) {
++			ext_background_effect_surface_v1_destroy(surface->background_effect);
++			surface->background_effect = NULL;
++		}
+ 		if (surface->surface != NULL) {
+ 			wl_surface_destroy(surface->surface);
+ 			surface->surface = NULL;
+@@ -652,6 +716,12 @@ static void send_frame(struct mako_surface *surface) {
+ 		surface->surface = wl_compositor_create_surface(state->compositor);
+ 		wl_surface_add_listener(surface->surface, &surface_listener, surface);
+ 
++		if (state->background_effect_manager != NULL) {
++			surface->background_effect =
++				ext_background_effect_manager_v1_get_background_effect(
++					state->background_effect_manager, surface->surface);
++		}
++
+ 		surface->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+ 			state->layer_shell, surface->surface, wl_output,
+ 			surface->layer, "notifications");
+@@ -682,6 +752,12 @@ static void send_frame(struct mako_surface *surface) {
+ 		zwlr_layer_surface_v1_set_margin(surface->layer_surface,
+ 			style->outer_margin.top, style->outer_margin.right,
+ 			style->outer_margin.bottom, style->outer_margin.left);
++		if (surface->background_effect != NULL && state->blur_supported) {
++			struct wl_region *blur_region = get_blur_region(surface);
++			ext_background_effect_surface_v1_set_blur_region(
++				surface->background_effect, blur_region);
++			wl_region_destroy(blur_region);
++		}
+ 		wl_surface_commit(surface->surface);
+ 
+ 		// Now we're going to bail without drawing anything. This gives the
+@@ -706,6 +782,13 @@ static void send_frame(struct mako_surface *surface) {
+ 	wl_surface_set_input_region(surface->surface, input_region);
+ 	wl_region_destroy(input_region);
+ 
++	if (surface->background_effect != NULL && state->blur_supported) {
++		struct wl_region *blur_region = get_blur_region(surface);
++		ext_background_effect_surface_v1_set_blur_region(
++			surface->background_effect, blur_region);
++		wl_region_destroy(blur_region);
++	}
++
+ 	wl_surface_set_buffer_scale(surface->surface, scale);
+ 	wl_surface_damage_buffer(surface->surface, 0, 0, INT32_MAX, INT32_MAX);
+ 	wl_surface_attach(surface->surface, surface->current_buffer->buffer, 0, 0);


### PR DESCRIPTION
## Summary
- Overlays `pkgs.mako` with a trimmed backport of [tpmajer's fork](tpmajer/mako@8b496324ea248c87d02050831aafabe51c53aa58), adding client-side support for the `ext-background-effect-v1` protocol.
- This lets mako notifications honor the blur `layer-rule` already configured for niri (`namespace="^notifications$"` in `modules/home/niri/includes/window-rules.kdl`) — niri 26.04 supports the protocol, but stock mako never requested it.
- Requested upstream in emersion/mako#631.
- Patch trimmed to drop the fork's own flake.nix/flake.lock/README packaging, which this overlay replaces (`makoOverlay` in `flake.nix`).

## Test plan
- [x] Patch applies cleanly against nixpkgs' exact pinned mako source (v1.11.0)
- [x] `pkgs.mako` builds successfully through the full `flake.overlays.default` chain (same composition every host/home-manager config uses)
- [x] `nix flake check` passes, including evaluating `nixosConfigurations.morpheus` and `.neo`
- [ ] Visual confirmation of blurred notification background on niri

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fse4iZdrDKPxSQWSzqZ2A